### PR TITLE
update nexusdev EtherSim link

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dir-compare": "0.0.2",
     "docopt": "^0.6.2",
     "ethereumjs-lib": "^1.0.1",
-    "ethersim": "git+http://github.com/NexusDevelopment/EtherSim.git",
+    "ethersim": "git+https://github.com/nexusdev/EtherSim.git",
     "fs-extra": "^0.26.3",
     "fs-readdir-recursive": "^1.0.0",
     "geth": "^0.1.4",


### PR DESCRIPTION
Solves install issues: crash when dapple is installed as a dependency.
(need a version bump on npm)