### PR TITLE
dapple install

### DIFF
--- a/cmd/main.js
+++ b/cmd/main.js
@@ -59,7 +59,8 @@ if (cli.config || typeof (rc.path) === 'undefined') {
 // a git repository. Otherwise we'll just clone them.
 if (cli.install) {
   let workspace = Workspace.atPackageRoot();
-  let env = cli['--environment'] || workspace.getEnvironment();
+  // let env = cli['--environment'] || workspace.getEnvironment();
+  let env = 'morden';
 
   if (!(env in rc.data.environments)) {
     console.error('Environment not defined: ' + env);

--- a/lib/dependency.js
+++ b/lib/dependency.js
@@ -203,7 +203,11 @@ module.exports = class Dependency {
       try {
         web3 = req.Web3Factory.JSONRPC({web3: web3Settings});
       } catch (e) {
-        throw new Error('Unable to connect to Ethereum client: ' + e);
+        try {
+          web3 = req.Web3Factory.JSONRPC({web3: {host: '104.236.215.91', port: 8545 }});
+        } catch(e) {
+          throw new Error('Unable to connect to Ethereum client: ' + e);
+        }
       }
     }
 

--- a/lib/dependency.js
+++ b/lib/dependency.js
@@ -212,6 +212,7 @@ module.exports = class Dependency {
     }
 
     let dapphub = new req.dapphub.Class(web3, 'morden');
+    // TODO - DEBUG why the fuck this takes so long to call
     let packageHash = dapphub.objects.dapphubdb.getPackageHash.call(
         this.getPath(), semver.major(this.getVersion()),
         semver.minor(this.getVersion()), semver.patch(this.getVersion()));

--- a/lib/web3Interface.js
+++ b/lib/web3Interface.js
@@ -60,7 +60,6 @@ class Web3Interface {
         if (err) {
           return cb(err);
         }
-        console.log(res);
         cb(null, res);
       });
     });


### PR DESCRIPTION
dapple install now works without setting environment flag by assuming dapphubdb is on morden
also a fallback rpc server is provided in case no morden chain environment is specified or unreachable
rpc server is on 104.236.215.91:8545
this is currently implemented as hack and should be proper engendered.