### PR TITLE
WIP Advanced Logging and Reporting

### DIFF
--- a/cmd/main.js
+++ b/cmd/main.js
@@ -148,6 +148,7 @@ if (cli.install) {
   let nameFilter;
   let workspace = Workspace.atPackageRoot();
   let env = cli['--environment'] || workspace.getEnvironment();
+  let report = cli['--report'] || false;
 
   if (!(env in rc.data.environments)) {
     console.error('Environment not defined: ' + env);
@@ -172,7 +173,8 @@ if (cli.install) {
     initStream = req.pipelines
       .BuildPipeline({
         packageRoot: Workspace.findPackageRoot(),
-        subpackages: cli['--subpackages'] || cli['-s']
+        subpackages: cli['--subpackages'] || cli['-s'],
+        report
       })
       .pipe(req.vinyl.dest(Workspace.findBuildPath()));
   }

--- a/constants/reporter.sol
+++ b/constants/reporter.sol
@@ -1,0 +1,22 @@
+import "dapple/dapple_log.sol";
+
+contract Reporter is DappleLogger {
+
+  modifier wrapCode(string what) {
+    __startBlock(what);
+    _
+    __stopBlock();
+  }
+
+  event __startBlockE(string what);
+  event __stopBlockE();
+  event setupReporter(string where);
+
+  function __startBlock(string what) {
+    __startBlockE(what);
+  }
+
+  function __stopBlock() {
+    __stopBlockE();
+  }
+}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -28,9 +28,10 @@ class Const {
 
     this.DAPPLE_VMTEST_CLASSES = {
       'dapple/test.sol': path.join(constants_directory, '/test.sol'),
-      'dapple/debug.sol': path.join(constants_directory, '/debug.sol')
+      'dapple/debug.sol': path.join(constants_directory, '/debug.sol'),
+      'dapple/reporter.sol': path.join(constants_directory, '/reporter.sol')
     };
-    this.DAPPLE_HEADERS = ['Test', 'Debug', 'Tester'];
+    this.DAPPLE_HEADERS = ['Test', 'Debug', 'Tester', 'Reporter'];
   }
   // Source object you can feed into solc module
   // TODO dapple-buildpack should be a proper package

--- a/lib/dependency.js
+++ b/lib/dependency.js
@@ -204,8 +204,8 @@ module.exports = class Dependency {
         web3 = req.Web3Factory.JSONRPC({web3: web3Settings});
       } catch (e) {
         try {
-          web3 = req.Web3Factory.JSONRPC({web3: {host: '104.236.215.91', port: 8545 }});
-        } catch(e) {
+          web3 = req.Web3Factory.JSONRPC({web3: {host: '104.236.215.91', port: 8545}});
+        } catch (e) {
           throw new Error('Unable to connect to Ethereum client: ' + e);
         }
       }

--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -154,27 +154,27 @@ class Interpreter {
     }
   }
 
-  eq(t1, t2) {
+  eq (t1, t2) {
     return t1.value === t2.value;
   }
 
-  neq(t1, t2) {
+  neq (t1, t2) {
     return t1.value !== t2.value;
   }
 
-  gt(t1, t2) {
+  gt (t1, t2) {
     return t1.value > t2.value;
   }
 
-  lt(t1, t2) {
+  lt (t1, t2) {
     return t1.value < t2.value;
   }
 
-  gte(t1, t2) {
+  gte (t1, t2) {
     return t1.value >= t2.value;
   }
 
-  lte(t1, t2) {
+  lte (t1, t2) {
     return t1.value <= t2.value;
   }
 
@@ -308,7 +308,7 @@ class Interpreter {
 
   getAddress (contract) {
     this.log(`GETADDRESS: ${contract.type.name}(${contract.value})\n`);
-    return contract.value;;
+    return contract.value;
   }
 }
 

--- a/lib/ipfs.js
+++ b/lib/ipfs.js
@@ -71,7 +71,7 @@ module.exports = class IPFS {
     return deasync(checkoutFiles).apply(this, arguments);
   }
 
-  addDirSync(relPath) {
+  addDirSync (relPath) {
     var absPath = path.resolve(relPath);
     var splitPath = absPath.split(path.sep);
     var dirname = splitPath[splitPath.length - 1];

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -230,7 +230,6 @@ class Linker {
     if (SOURCEMAP_KEY in sources) {
       linked[SOURCEMAP_KEY] = sources[SOURCEMAP_KEY];
     }
-
     return linked;
   }
 

--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -17,6 +17,26 @@ const hexTranslators = {
 };
 
 module.exports = class LogTranslator {
+
+  static addGenericLog (name, format) {
+    if (!LogTranslator.logs) LogTranslator.logs = {};
+    LogTranslator.logs[name] = format;
+  }
+
+  static format (entry) {
+    let out = LogTranslator.logs[entry.event];
+    out = out
+      .split('`')
+      .map( (str, num) => {
+        if(num%2===0) return str;
+        let name = str
+          .split(' ')[1] // get the name
+          .replace('.','_'); // substitude illigal chars
+        return entry.args[name];
+      })
+    return out.join('');
+  }
+
   constructor (abi) {
     var that = this;
 

--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -14,7 +14,9 @@ const hexTranslators = {
   'int': (hex) => web3.toBigNumber(hex).toString(),
   'uint': (hex) => web3.toBigNumber(hex).toString(),
   'address': (hex) => hex,
-  'bytes[]': (hex) => hex.map( b => b.slice(2) ).join('')
+  'bytes[]': (hex) => hex.map( b => b.slice(2) ).join(''),
+  'uint[]': (hex) => hex.join(', ')
+
 };
 
 module.exports = class LogTranslator {

--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -13,7 +13,8 @@ const hexTranslators = {
   'string': (hex) => web3.toAscii(hex).replace(/\u0000/g, ''),
   'int': (hex) => web3.toBigNumber(hex).toString(),
   'uint': (hex) => web3.toBigNumber(hex).toString(),
-  'address': (hex) => hex
+  'address': (hex) => hex,
+  'bytes[]': (hex) => hex.map( b => b.slice(2) ).join('')
 };
 
 module.exports = class LogTranslator {
@@ -32,7 +33,7 @@ module.exports = class LogTranslator {
         if(num%2===0) return str;
         let name = str
           .split(' ')[1] // get the name
-          .replace('.','_'); // substitude illigal chars
+          .replace(/\.|\[|\]|\)|\(/g,'_'); // substitude illigal chars
         return entry.args[name];
       })
     return type.toUpperCase() + ':  ' + out.join('');

--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -18,13 +18,14 @@ const hexTranslators = {
 
 module.exports = class LogTranslator {
 
-  static addGenericLog (name, format) {
+  static addGenericLog (name, type, format) {
     if (!LogTranslator.logs) LogTranslator.logs = {};
-    LogTranslator.logs[name] = format;
+    LogTranslator.logs[name] = {type, format};
   }
 
   static format (entry) {
-    let out = LogTranslator.logs[entry.event];
+    let type = LogTranslator.logs[entry.event].type;
+    let out = LogTranslator.logs[entry.event].format;
     out = out
       .split('`')
       .map( (str, num) => {
@@ -34,7 +35,7 @@ module.exports = class LogTranslator {
           .replace('.','_'); // substitude illigal chars
         return entry.args[name];
       })
-    return out.join('');
+    return type.toUpperCase() + ':  ' + out.join('');
   }
 
   constructor (abi) {

--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -38,7 +38,11 @@ module.exports = class LogTranslator {
           .replace(/\.|\[|\]|\)|\(|\+|\-|\s+|\=|\<|\>/g,'_'); // substitude illigal chars
         return entry.args[name];
       });
-    return type.toUpperCase() + ':  ' + out.join('');
+    if (type === 'doc') {
+      return out.join('');
+    } else {
+      return type.toUpperCase() + ':  ' + out.join('');
+    }
   }
 
   constructor (abi) {

--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -10,7 +10,7 @@ const hexTranslators = {
   'bool': (hex) => hex,
   'bytes': (hex) => hex,
   'logs': (hex) => web3.toAscii(hex).replace(/\u0000/g, ''),
-  'string': (hex) => web3.toAscii(hex).replace(/\u0000/g, ''),
+  'string': (hex) => hex,
   'int': (hex) => web3.toBigNumber(hex).toString(),
   'uint': (hex) => web3.toBigNumber(hex).toString(),
   'address': (hex) => hex,
@@ -28,14 +28,16 @@ module.exports = class LogTranslator {
     let type = LogTranslator.logs[entry.event].type;
     let out = LogTranslator.logs[entry.event].format;
     out = out
+      .replace(/\\`/g,'\0')
       .split('`')
       .map( (str, num) => {
-        if(num%2===0) return str;
+        if(num%2===0) return str.replace(/\0/g,'`');
         let name = str
+          .replace(/\0/g,'`')
           .split(' ')[1] // get the name
           .replace(/\.|\[|\]|\)|\(|\+|\-|\s+|\=|\<|\>/g,'_'); // substitude illigal chars
         return entry.args[name];
-      })
+      });
     return type.toUpperCase() + ':  ' + out.join('');
   }
 

--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -14,7 +14,7 @@ const hexTranslators = {
   'int': (hex) => web3.toBigNumber(hex).toString(),
   'uint': (hex) => web3.toBigNumber(hex).toString(),
   'address': (hex) => hex,
-  'bytes[]': (hex) => hex.map( b => b.slice(2) ).join(''),
+  'bytes[]': (hex) => hex.map(b => b.slice(2)).join(''),
   'uint[]': (hex) => hex.join(', ')
 
 };
@@ -30,14 +30,14 @@ module.exports = class LogTranslator {
     let type = LogTranslator.logs[entry.event].type;
     let out = LogTranslator.logs[entry.event].format;
     out = out
-      .replace(/\\`/g,'\0')
+      .replace(/\\`/g, '\0')
       .split('`')
-      .map( (str, num) => {
-        if(num%2===0) return str.replace(/\0/g,'`');
+      .map((str, num) => {
+        if (num % 2 === 0) return str.replace(/\0/g, '`');
         let name = str
-          .replace(/\0/g,'`')
+          .replace(/\0/g, '`')
           .split(' ')[1] // get the name
-          .replace(/\.|\[|\]|\)|\(|\+|\-|\s+|\=|\<|\>/g,'_'); // substitude illigal chars
+          .replace(/\.|\[|\]|\)|\(|\+|\-|\s+|\=|\<|\>/g, '_'); // substitude illigal chars
         return entry.args[name];
       });
     if (type === 'doc') {

--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -33,7 +33,7 @@ module.exports = class LogTranslator {
         if(num%2===0) return str;
         let name = str
           .split(' ')[1] // get the name
-          .replace(/\.|\[|\]|\)|\(/g,'_'); // substitude illigal chars
+          .replace(/\.|\[|\]|\)|\(|\+|\-|\s+|\=|\<|\>/g,'_'); // substitude illigal chars
         return entry.args[name];
       })
     return type.toUpperCase() + ':  ' + out.join('');

--- a/lib/pipelines.js
+++ b/lib/pipelines.js
@@ -47,6 +47,9 @@ var SourcePipeline = function (opts) {
   return Combine(
     streams.package_stream(opts.packageRoot),
 
+    // Extendable preprocessor
+    streams.xpreprocess(opts),
+
     // Inject a couple built-in contracts.
     streams.inject_virtual_contracts(),
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -12,6 +12,7 @@ module.exports = require('lazreq')({
   PackageBuildFilter: './streams/package_build_filter_stream.js',
   package_stream: './streams/package_stream.js',
   preprocess: './streams/preprocess.js',
+  xpreprocess: './streams/xpreprocess.js',
   test: './streams/test.js',
   test_summarizer: './streams/test_summarizer.js',
   file_logger: './streams/file_logger.js',

--- a/lib/streams/js_postprocess.js
+++ b/lib/streams/js_postprocess.js
@@ -22,7 +22,7 @@ module.exports = function (opts) {
 
     if (opts.nameFilter) {
       classes = _.pick(classes, _.filter(_.keys(classes), function (name) {
-         return opts.nameFilter.test(name);
+        return opts.nameFilter.test(name);
       }));
     }
 

--- a/lib/streams/preprocess.js
+++ b/lib/streams/preprocess.js
@@ -19,12 +19,9 @@ module.exports = function (preprocessorVars) {
       let file = sources[i];
 
       if (/\.sol$/i.test(file.path)) {
-        let vars = _.assign(
-          workspace.getPreprocessorVars(file.path), preprocessorVars);
-
+        let vars = _.assign(workspace.getPreprocessorVars(file.path), preprocessorVars);
         try {
-          file.contents = new Buffer(
-            _.template(String(file.contents))(vars));
+          file.contents = new Buffer(_.template(String(file.contents))(vars));
         } catch (err) {
           throw new Error("Error preprocessing '" + file.path + "': " + err);
         }

--- a/lib/streams/publish.js
+++ b/lib/streams/publish.js
@@ -31,27 +31,25 @@ var createPackageHeader = function (contracts, rootHash, dappfile, schema) {
   return header;
 };
 
-var processClasses = function( _classes ) {
-  var classes = {};
-  _.each(_classes, (obj, key) => {
-    var Class = {
-      bytecode: obj.bytecode,
-      interface: JSON.parse(obj.interface),
-      solidity_interface: obj.solidity_interface
-    };
-    var link = ipfs.addJsonSync(Class);
-    contracts[key] = link;
-  });
-  return classes;
-}
-
 module.exports = function (opts) {
   var ipfs = new Ipfs(opts);
+  var processClasses = function (_classes) {
+    var classes = {};
+    _.each(_classes, (obj, key) => {
+      var Class = {
+        bytecode: obj.bytecode,
+        interface: JSON.parse(obj.interface),
+        solidity_interface: obj.solidity_interface
+      };
+      var link = ipfs.addJsonSync(Class);
+      classes[key] = link;
+    });
+    return classes;
+  };
   return through.obj(function (file, enc, cb) {
     if (file.path === 'classes.json') {
-
       // Build Package Header
-      var classes = processClasses(String(file.contents));
+      var contracts = processClasses(String(file.contents));
       var rootHash = ipfs.addDirSync(opts.path);
       var schemaHash = ipfs.addJsonSync(schemas.package.schema);
       var header = createPackageHeader(contracts, rootHash, opts.dappfile, schemaHash);

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -52,6 +52,8 @@ function runTests (stream, className, vmTest, logTranslator) {
     for (let entry of result.logs) {
       if (entry.event.indexOf('_named_') > -1) {
         output += logPrefix + entry.args.key + ': ' + entry.args.val + '\n';
+      } else if (entry.event.indexOf('log_id_') > -1 ) {
+        output += logPrefix + LogTranslator.format(entry) + '\n';
       } else {
         output += logPrefix + entry.event + '\n';
 
@@ -131,7 +133,6 @@ module.exports = function (opts) {
            .length !== testContract.signatures.length) {
         continue;
       }
-
       let translator = opts.logTranslator || new LogTranslator(contract.abi);
       let vmTest = opts.vmTest || new VMTest(web3, contract, translator);
       let stream = opts.stream || this;

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -7,6 +7,7 @@ var deasync = require('deasync');
 var File = require('vinyl');
 var LogTranslator = require('../logtranslator');
 var path = require('path');
+var fs = require('fs');
 var through = require('through2');
 var VMTest = require('../vmtest');
 var Web3Factory = require('../web3Factory');
@@ -48,9 +49,17 @@ function runTests (stream, className, vmTest, logTranslator) {
     // its own function or class somewhere.
     var output = result.title + '\n';
     var logPrefix = '  LOG:  ';
-
+    var report = '';
     for (let entry of result.logs) {
-      if (entry.event.indexOf('_named_') > -1) {
+      if( entry.event === 'setupReporter' ) {
+        console.log(entry);
+      } else if( entry.event === '__startBlockE' ) {
+        report += '```{' + entry.args.what + '}\n';
+      } else if( entry.event === '__stopBlockE' ) {
+        report += '```\n';
+      } else if( entry.event.indexOf('log_id_') > -1 && LogTranslator.logs[entry.event].type === 'doc' ) {
+        report += LogTranslator.format(entry) + '\n';
+      } else if (entry.event.indexOf('_named_') > -1) {
         output += logPrefix + entry.args.key + ': ' + entry.args.val + '\n';
       } else if (entry.event.indexOf('log_id_') > -1 ) {
         output += '  ' + LogTranslator.format(entry) + '\n';
@@ -64,6 +73,10 @@ function runTests (stream, className, vmTest, logTranslator) {
       }
     }
     output += '  ' + color(result.message) + '\n';
+    // TODO refactor to write report stream file
+    if( result.reporterPath ) {
+      fs.appendFileSync(result.reporterPath, report);
+    }
 
     var file = new File({
       path: path.join(

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -51,15 +51,15 @@ function runTests (stream, className, vmTest, logTranslator) {
     var logPrefix = '  LOG:  ';
     var report = '';
     for (let entry of result.logs) {
-      if( entry.event === '__startBlockE' ) {
+      if (entry.event === '__startBlockE') {
         report += '```{' + entry.args.what + '}\n';
-      } else if( entry.event === '__stopBlockE' ) {
+      } else if (entry.event === '__stopBlockE') {
         report += '```\n';
-      } else if( entry.event.indexOf('log_id_') > -1 && LogTranslator.logs[entry.event].type === 'doc' ) {
+      } else if (entry.event.indexOf('log_id_') > -1 && LogTranslator.logs[entry.event].type === 'doc') {
         report += LogTranslator.format(entry) + '\n';
       } else if (entry.event.indexOf('_named_') > -1) {
         output += logPrefix + entry.args.key + ': ' + entry.args.val + '\n';
-      } else if (entry.event.indexOf('log_id_') > -1 ) {
+      } else if (entry.event.indexOf('log_id_') > -1) {
         output += '  ' + LogTranslator.format(entry) + '\n';
       } else {
         output += logPrefix + entry.event + '\n';
@@ -72,7 +72,7 @@ function runTests (stream, className, vmTest, logTranslator) {
     }
     output += '  ' + color(result.message) + '\n';
     // TODO refactor to write report stream file
-    if( result.reporterPath ) {
+    if (result.reporterPath) {
       fs.appendFileSync(result.reporterPath, report);
     }
 

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -53,7 +53,7 @@ function runTests (stream, className, vmTest, logTranslator) {
       if (entry.event.indexOf('_named_') > -1) {
         output += logPrefix + entry.args.key + ': ' + entry.args.val + '\n';
       } else if (entry.event.indexOf('log_id_') > -1 ) {
-        output += logPrefix + LogTranslator.format(entry) + '\n';
+        output += '  ' + LogTranslator.format(entry) + '\n';
       } else {
         output += logPrefix + entry.event + '\n';
 

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -51,9 +51,7 @@ function runTests (stream, className, vmTest, logTranslator) {
     var logPrefix = '  LOG:  ';
     var report = '';
     for (let entry of result.logs) {
-      if( entry.event === 'setupReporter' ) {
-        console.log(entry);
-      } else if( entry.event === '__startBlockE' ) {
+      if( entry.event === '__startBlockE' ) {
         report += '```{' + entry.args.what + '}\n';
       } else if( entry.event === '__stopBlockE' ) {
         report += '```\n';

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -33,7 +33,9 @@ module.exports = function (opts) {
               let types = hit
                   .split('`')
                   .filter((a, k) => k%2===1)
-                  .map( t=>t.split(' '));
+                  .map( t=>{
+                    if( t.indexOf(' ') == -1 ) throw new Error('Log statements has to follow the form: `<type> <name>`');
+                    return t.split(' ')});
               let vars = types
                   .map(t => t[0] + ' ' + t[1].replace(/\.|\[|\]|\)|\(/g,'_'));
               // Add generic log to LoGTranslator to display it nicely in the future

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -26,9 +26,9 @@ module.exports = function (opts) {
         opts.web3 === 'internal' && // only on internal chains
         /\.sol$/i.test(file.path) // is solidity contract
       ) {
-        if( RegExp(/^\s*\/\/@log/gm).test(content) ) { // has log statements inside
+        if( RegExp(/^\s*\/\/@(warn|info|debug|log)/gm).test(content) ) { // has log statements inside
           content = content // update content
-            .replace(/\/\/@log\s*(.*)$/gm, function( match, hit ) { // replace the log lines
+            .replace(/\/\/@(warn|info|debug|log)\s*(.*)$/gm, function( match, type, hit ) { // replace the log lines
               let eventName = `${GENERIC_LOG_PREFIX}${logCounter++}`;
               let types = hit
                   .split('`')
@@ -37,7 +37,7 @@ module.exports = function (opts) {
               let vars = types
                   .map(t => t.join(' ').replace('.','_'));
               // Add generic log to LoGTranslator to display it nicely in the future
-              LogTranslator.addGenericLog (eventName, hit);
+              LogTranslator.addGenericLog (eventName, type, hit);
               // Save logger
               logger.push({
                 target: match,
@@ -57,12 +57,10 @@ module.exports = function (opts) {
       this.push(file);
     }
     // if there is something to log, inject logger
-    if( logger.length > 0 ) {
-      this.push(new File({
-        path: "dapple/dapple_log.sol",
-        contents: new Buffer(`contract DappleLogger {\n${logger.map(l => l.signature).join('\n')}\n}`)
-      }));
-    }
+    this.push(new File({
+      path: "dapple/dapple_log.sol",
+      contents: new Buffer(`contract DappleLogger {\n${logger.map(l => l.signature).join('\n')}\n}`)
+    }));
     cb();
   });
 };

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -23,7 +23,8 @@ module.exports = function (opts) {
 
       if (
         opts.web3 === 'internal' && // only on internal chains
-        /\.sol$/i.test(file.path) // is solidity contract
+        /\.sol$/i.test(file.path) && // is solidity contract
+        opts.report
       ) {
         if (RegExp(/^\s*\/\/@(warn|info|debug|log|doc)/gm).test(content)) { // has log statements inside
           content = content // update content
@@ -53,7 +54,7 @@ module.exports = function (opts) {
             });
         } // if has logs
         content = content
-          .replace(/^\s*contract([^{]*){/gm, function (match, hit) { // inject DappleLogger contract
+          .replace(/^\s*contract\s([^{]*){/gm, function (match, hit) { // inject DappleLogger contract
             return `contract ${RegExp(/\sis\s/gm).test(hit) ? (hit.replace(/\sis\s/gm, ' is DappleLogger, ')) : (hit + 'is DappleLogger')} {`;
           });
         // inject import

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -2,8 +2,10 @@
 
 var _ = require('lodash');
 var through = require('through2');
-var Workspace = require('../workspace.js');
 var File = require('vinyl');
+var LogTranslator = require('../logtranslator.js');
+
+var GENERIC_LOG_PREFIX = 'log_id_';
 
 // Runs and expands any Lodash template directives in the source code.
 module.exports = function (opts) {
@@ -13,7 +15,6 @@ module.exports = function (opts) {
     sources.push(file);
     cb();
   }, function (cb) {
-    var workspace = new Workspace(sources);
     var logger = [];
     var logCounter = 0;
 
@@ -23,29 +24,36 @@ module.exports = function (opts) {
 
       if (
         opts.web3 === 'internal' && // only on internal chains
-        /\.sol$/i.test(file.path) && // is solidity contract
-        RegExp(/^\s*\/\/@log/gm).test(content) // has log statements inside
+        /\.sol$/i.test(file.path) // is solidity contract
       ) {
-        content = content // update content
-          .replace(/\/\/@log\s*(.*)$/gm, function( match, hit ) { // replace the log lines
-            let types = hit
-                .split('`')
-                .filter((a, k) => k%2===1)
-                .map( t=>t.split(' '));
-            // Save logger
-            logger.push({
-              target: match,
-              signature: `event log_id_${logCounter}(${types.map( t=> t[0] ).join(',')});`
+        if( RegExp(/^\s*\/\/@log/gm).test(content) ) { // has log statements inside
+          content = content // update content
+            .replace(/\/\/@log\s*(.*)$/gm, function( match, hit ) { // replace the log lines
+              let eventName = `${GENERIC_LOG_PREFIX}${logCounter++}`;
+              let types = hit
+                  .split('`')
+                  .filter((a, k) => k%2===1)
+                  .map( t=>t.split(' '));
+              let vars = types
+                  .map(t => t.join(' ').replace('.','_'));
+              // Add generic log to LoGTranslator to display it nicely in the future
+              LogTranslator.addGenericLog (eventName, hit);
+              // Save logger
+              logger.push({
+                target: match,
+                signature: `event ${eventName}(${vars.join(',')});`
+              });
+              return `${eventName}(${types.map( t=> t[1] ).join(',')});`;
             });
-            return `log_id_${logCounter++}(${types.map( t=> t[1] ).join(',')});`;
-          })
+        } // if has logs
+        content = content
           .replace(/^\s*contract([^{]*){/gm, function( match, hit ){ // inject DappleLogger contract
             return `contract ${hit}${RegExp(/\sis\s/gm).test(hit)?',':'is'} DappleLogger {`;
           });
-          // inject import
-          content = 'import "dapple/dapple_log.sol";\n'+ content;
-        file.contents = new Buffer(content);
+        // inject import
+        content = 'import "dapple/dapple_log.sol";\n'+ content;
       }
+      file.contents = new Buffer(content);
       this.push(file);
     }
     // if there is something to log, inject logger

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var _ = require('lodash');
+var through = require('through2');
+var Workspace = require('../workspace.js');
+var File = require('vinyl');
+
+// Runs and expands any Lodash template directives in the source code.
+module.exports = function (opts) {
+  var sources = [];
+
+  return through.obj(function (file, enc, cb) {
+    sources.push(file);
+    cb();
+  }, function (cb) {
+    var workspace = new Workspace(sources);
+    var logger = [];
+    var logCounter = 0;
+
+    for (let i = 0; i < sources.length; i += 1) {
+      let file = sources[i];
+      let content = String(file.contents);
+
+      if (
+        opts.web3 === 'internal' && // only on internal chains
+        /\.sol$/i.test(file.path) && // is solidity contract
+        RegExp(/^\s*\/\/@log/gm).test(content) // has log statements inside
+      ) {
+        content = content // update content
+          .replace(/\/\/@log\s*(.*)$/gm, function( match, hit ) { // replace the log lines
+            let types = hit
+                .split('`')
+                .filter((a, k) => k%2===1)
+                .map( t=>t.split(' '));
+            // Save logger
+            logger.push({
+              target: match,
+              signature: `event log_id_${logCounter}(${types.map( t=> t[0] ).join(',')});`
+            });
+            return `log_id_${logCounter++}(${types.map( t=> t[1] ).join(',')});`;
+          })
+          .replace(/^\s*contract([^{]*){/gm, function( match, hit ){ // inject DappleLogger contract
+            return `contract ${hit}${RegExp(/\sis\s/gm).test(hit)?',':'is'} DappleLogger {`;
+          });
+          // inject import
+          content = 'import "dapple/dapple_log.sol";\n'+ content;
+        file.contents = new Buffer(content);
+      }
+      this.push(file);
+    }
+    // if there is something to log, inject logger
+    if( logger.length > 0 ) {
+      this.push(new File({
+        path: "dapple/dapple_log.sol",
+        contents: new Buffer(`contract DappleLogger {\n${logger.map(l => l.signature).join('\n')}\n}`)
+      }));
+    }
+    cb();
+  });
+};

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -37,7 +37,7 @@ module.exports = function (opts) {
                     if( t.indexOf(' ') == -1 ) throw new Error('Log statements has to follow the form: `<type> <name>`');
                     return t.split(' ')});
               let vars = types
-                  .map(t => t[0] + ' ' + t[1].replace(/\.|\[|\]|\)|\(/g,'_'));
+                  .map(t => t[0] + ' ' + t[1].replace(/\.|\[|\]|\)|\(|\+|\-|\s+|\=|\<|\>/g,'_'));
               // Add generic log to LoGTranslator to display it nicely in the future
               LogTranslator.addGenericLog (eventName, type, hit);
               // Save logger
@@ -50,7 +50,7 @@ module.exports = function (opts) {
         } // if has logs
         content = content
           .replace(/^\s*contract([^{]*){/gm, function( match, hit ){ // inject DappleLogger contract
-            return `contract ${hit}${RegExp(/\sis\s/gm).test(hit)?',':'is'} DappleLogger {`;
+            return `contract ${RegExp(/\sis\s/gm).test(hit)?(hit.replace(/\sis\s/gm,' is DappleLogger, ')):(hit+'is DappleLogger')} {`;
           });
         // inject import
         content = 'import "dapple/dapple_log.sol";\n'+ content;

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -26,12 +26,13 @@ module.exports = function (opts) {
         opts.web3 === 'internal' && // only on internal chains
         /\.sol$/i.test(file.path) // is solidity contract
       ) {
-        if( RegExp(/^\s*\/\/@(warn|info|debug|log)/gm).test(content) ) { // has log statements inside
+        if( RegExp(/^\s*\/\/@(warn|info|debug|log|doc)/gm).test(content) ) { // has log statements inside
           content = content // update content
-            .replace(/\/\/@(warn|info|debug|log)\s*(.*)$/gm, function( match, type, hit ) { // replace the log lines
+            .replace(/\/\/@(warn|info|debug|log|doc)\s*(.*)$/gm, function( match, type, hit ) { // replace the log lines
               let eventName = `${GENERIC_LOG_PREFIX}${logCounter++}`;
               let types = hit
-                  .split('`')
+                  .replace(/\\`/g,'\0')
+                  .split(/`/)
                   .filter((a, k) => k%2===1)
                   .map( t=>{
                     if( t.indexOf(' ') == -1 ) throw new Error('Log statements has to follow the form: `<type> <name>`');
@@ -41,6 +42,9 @@ module.exports = function (opts) {
               // Add generic log to LoGTranslator to display it nicely in the future
               LogTranslator.addGenericLog (eventName, type, hit);
               // Save logger
+              // TODO - ressearch if explicite type declaration can be omitted and instread
+              // replaced with every type signature, the solc compiler then picks the correct types
+              // much like assert generation in tests
               logger.push({
                 target: match,
                 signature: `event ${eventName}(${vars.join(',')});`

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var through = require('through2');
 var File = require('vinyl');
 var LogTranslator = require('../logtranslator.js');
@@ -26,21 +25,22 @@ module.exports = function (opts) {
         opts.web3 === 'internal' && // only on internal chains
         /\.sol$/i.test(file.path) // is solidity contract
       ) {
-        if( RegExp(/^\s*\/\/@(warn|info|debug|log|doc)/gm).test(content) ) { // has log statements inside
+        if (RegExp(/^\s*\/\/@(warn|info|debug|log|doc)/gm).test(content)) { // has log statements inside
           content = content // update content
-            .replace(/\/\/@(warn|info|debug|log|doc)\s*(.*)$/gm, function( match, type, hit ) { // replace the log lines
+            .replace(/\/\/@(warn|info|debug|log|doc)\s*(.*)$/gm, function (match, type, hit) { // replace the log lines
               let eventName = `${GENERIC_LOG_PREFIX}${logCounter++}`;
               let types = hit
-                  .replace(/\\`/g,'\0')
+                  .replace(/\\`/g, '\0')
                   .split(/`/)
-                  .filter((a, k) => k%2===1)
-                  .map( t=>{
-                    if( t.indexOf(' ') == -1 ) throw new Error('Log statements has to follow the form: `<type> <name>`');
-                    return t.split(' ')});
+                  .filter((a, k) => k % 2 === 1)
+                  .map(t => {
+                    if (t.indexOf(' ') === -1) throw new Error('Log statements has to follow the form: `<type> <name>`');
+                    return t.split(' ');
+                  });
               let vars = types
-                  .map(t => t[0] + ' ' + t[1].replace(/\.|\[|\]|\)|\(|\+|\-|\s+|\=|\<|\>/g,'_'));
+                  .map(t => t[0] + ' ' + t[1].replace(/\.|\[|\]|\)|\(|\+|\-|\s+|\=|\<|\>/g, '_'));
               // Add generic log to LoGTranslator to display it nicely in the future
-              LogTranslator.addGenericLog (eventName, type, hit);
+              LogTranslator.addGenericLog(eventName, type, hit);
               // Save logger
               // TODO - ressearch if explicite type declaration can be omitted and instread
               // replaced with every type signature, the solc compiler then picks the correct types
@@ -49,22 +49,22 @@ module.exports = function (opts) {
                 target: match,
                 signature: `event ${eventName}(${vars.join(',')});`
               });
-              return `${eventName}(${types.map( t=> t[1] ).join(',')});`;
+              return `${eventName}(${types.map(t => t[1]).join(',')});`;
             });
         } // if has logs
         content = content
-          .replace(/^\s*contract([^{]*){/gm, function( match, hit ){ // inject DappleLogger contract
-            return `contract ${RegExp(/\sis\s/gm).test(hit)?(hit.replace(/\sis\s/gm,' is DappleLogger, ')):(hit+'is DappleLogger')} {`;
+          .replace(/^\s*contract([^{]*){/gm, function (match, hit) { // inject DappleLogger contract
+            return `contract ${RegExp(/\sis\s/gm).test(hit) ? (hit.replace(/\sis\s/gm, ' is DappleLogger, ')) : (hit + 'is DappleLogger')} {`;
           });
         // inject import
-        content = 'import "dapple/dapple_log.sol";\n'+ content;
+        content = 'import "dapple/dapple_log.sol";\n' + content;
       }
       file.contents = new Buffer(content);
       this.push(file);
     }
     // if there is something to log, inject logger
     this.push(new File({
-      path: "dapple/dapple_log.sol",
+      path: 'dapple/dapple_log.sol',
       contents: new Buffer(`contract DappleLogger {\n${logger.map(l => l.signature).join('\n')}\n}`)
     }));
     cb();

--- a/lib/streams/xpreprocess.js
+++ b/lib/streams/xpreprocess.js
@@ -35,7 +35,7 @@ module.exports = function (opts) {
                   .filter((a, k) => k%2===1)
                   .map( t=>t.split(' '));
               let vars = types
-                  .map(t => t.join(' ').replace('.','_'));
+                  .map(t => t[0] + ' ' + t[1].replace(/\.|\[|\]|\)|\(/g,'_'));
               // Add generic log to LoGTranslator to display it nicely in the future
               LogTranslator.addGenericLog (eventName, type, hit);
               // Save logger

--- a/lib/vmtest.js
+++ b/lib/vmtest.js
@@ -25,6 +25,7 @@ module.exports = class VMTest {
     this.web3 = web3;
     this.contract = contract;
     this.logTranslator = logTranslator;
+    this.reporterPath = false;
 
     if (!logTranslator) {
       this.logTranslator = new LogTranslator(contract.abi);
@@ -56,7 +57,7 @@ module.exports = class VMTest {
     fs.writeFileSync(utils.classToFilename(testClassName), test);
   }
 
-  static testResult (failed, title, message, logs) {
+  static testResult (failed, title, message, logs, reporterPath) {
     // TODO: Replace with proper JSON schema validation.
     if (typeof failed === 'undefined') {
       throw new Error('testResult requires a boolean as the 1st argument.');
@@ -78,7 +79,8 @@ module.exports = class VMTest {
       title: title,
       message: message,
       logs: logs,
-      failed: failed
+      failed: failed,
+      reporterPath: reporterPath
     };
   }
 
@@ -114,6 +116,14 @@ module.exports = class VMTest {
           if (err) {
             cb(err, VMTest.testResult(true, 'setUp failed', err));
             return;
+          }
+
+          if( !that.reporterPath ) {
+            var reporterLog = that.logTranslator.translateAll(receipt.logs.filter( l => l.topics.length > 0 && l.topics[0] === '0x2ef9ea3c32090ed6e07dce1537a1ff386ee09eb5e752f0387a46c9a90bd31642' ));
+            if( reporterLog.length > 0 ) {
+              that.reporterPath = reporterLog[0].args.where;
+              fs.writeFileSync(that.reporterPath, ''); // clear file
+            }
           }
 
           runTestOn(contract);
@@ -316,7 +326,7 @@ module.exports = class VMTest {
             message = err || (failed ? 'Failed!' : 'Passed!');
           }
 
-          cb(err, VMTest.testResult(failed, testString, message, logs));
+          cb(err, VMTest.testResult(failed, testString, message, logs, that.reporterPath));
         });
       });
     }

--- a/lib/vmtest.js
+++ b/lib/vmtest.js
@@ -118,9 +118,11 @@ module.exports = class VMTest {
             return;
           }
 
-          if( !that.reporterPath ) {
-            var reporterLog = that.logTranslator.translateAll(receipt.logs.filter( l => l.topics.length > 0 && l.topics[0] === '0x2ef9ea3c32090ed6e07dce1537a1ff386ee09eb5e752f0387a46c9a90bd31642' ));
-            if( reporterLog.length > 0 ) {
+          if (!that.reporterPath) {
+            var reporterLog = that.logTranslator.translateAll(
+              receipt.logs.filter(l => l.topics.length > 0 &&
+                l.topics[0] === '0x2ef9ea3c32090ed6e07dce1537a1ff386ee09eb5e752f0387a46c9a90bd31642'));
+            if (reporterLog.length > 0) {
               that.reporterPath = reporterLog[0].args.where;
               fs.writeFileSync(that.reporterPath, ''); // clear file
             }

--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -165,10 +165,9 @@ module.exports = class Workspace {
         !(/\/\.|^\./).test(f) && // ignores dot directories
         (self.dappfile.ignore || [])
           .map(ignore => !(new RegExp(ignore)).test(f))
-          .reduce( (a,b) => a && b, true );
+          .reduce((a, b) => a && b, true);
     });
-  };
-
+  }
 
   get dappfile () {
     return this._dappfile || {};
@@ -335,14 +334,13 @@ module.exports = class Workspace {
   // recieves a path String, resolves it and whitelists all paths for inclusion
   // to a package
   addPath (path) {
-
     var files = this.filterFiles(Workspace.getFiles(path));
-    if(!this.dappfile.files) {
+    if (!this.dappfile.files) {
       this.dappfile.files = [];
     }
     let diff = _.difference(files, this.dappfile.files);
 
-    if( diff.length > 0 ) {
+    if (diff.length > 0) {
       this.dappfile.files = diff.concat(this.dappfile.files);
       console.log(`added: \n  ${ diff.join('\n  ') }`);
       this.writeDappfile();
@@ -355,7 +353,7 @@ module.exports = class Workspace {
     if (!this.dappfile.ignore) {
       this.dappfile.ignore = [];
     }
-    if (this.dappfile.ignore.indexOf(path) == -1) {
+    if (this.dappfile.ignore.indexOf(path) === -1) {
       this.dappfile.ignore.push(path);
       let filtered = this.filterFiles(this.dappfile.files);
       let diff = _.difference(this.dappfile.files, filtered);

--- a/test/_fixtures/golden/js_module.js
+++ b/test/_fixtures/golden/js_module.js
@@ -28,7 +28,7 @@ dapple['golden'] = (function builder () {
   };
 
   // Wrap pass-through functions by name.
-  var passthroughs = ["at","new"];
+  var passthroughs = ['at', 'new'];
   for (var i = 0; i < passthroughs.length; i += 1) {
     ContractWrapper.prototype[passthroughs[i]] = (function (passthrough) {
       return function () {

--- a/test/_fixtures/golden/js_module.js
+++ b/test/_fixtures/golden/js_module.js
@@ -28,7 +28,7 @@ dapple['golden'] = (function builder () {
   };
 
   // Wrap pass-through functions by name.
-  var passthroughs = ['at', 'new'];
+  var passthroughs = ["at","new"];
   for (var i = 0; i < passthroughs.length; i += 1) {
     ContractWrapper.prototype[passthroughs[i]] = (function (passthrough) {
       return function () {

--- a/test/linker_test.js
+++ b/test/linker_test.js
@@ -91,9 +91,9 @@ describe('Linker', function () {
     var map = Linker.link(workspace, sources)[Linker.CONTRACTMAP_KEY];
     var contractNames = _.values(JSON.parse(map)).sort();
     assert.deepEqual(contractNames, [
-      'DapplePkgContract', 'Debug', 'LinkerExample',
+      'DappleLogger', 'DapplePkgContract', 'Debug', 'LinkerExample',
       'ParenExample', 'PkgContract', 'PkgContract_Test',
-      'Test', 'Tester'
+      'Reporter', 'Test', 'Tester'
     ]);
   });
 


### PR DESCRIPTION
This branch tries to improve the current logger.

#### NatSpec debugger
This addresses #155 and #143

It is possible to use this statements in any solidity code:
```
contract Contract {
    function send (address addr, uint value) {
        //@info user `address addr` has deposit `uint value`eth
        [...]
        //@warn something happened: "`string message`"
    }
}
```
Which on **internal** chains will produce the following log output if executed:
```
INFO:  user 0x4cfcedde6a51e5f6b47da226e50c2bb8b055ee62 has deposit 200eth
WARN:  something happened: "a strange loop"
```
On external chains (rpc/ipc connected) the statements are treated as comments and ignored during deploy.

The statements has to have one of the following prefixes:
* `//@warn`
* `//@info`
* `//@log`
* `//@debug`

Expressions which are surrounded by "\`" has to be in the following form: `<type> <reference>` while
__type__ has to be a valid solidity type and __reference__ points to an actual variable in your solidity code


### Reporter

additional to the logging output to stdout a reporter can be enabled:
In order to use the reporter, inherit from the Reporter contract:
```
contract MyTester is Reporter {
[...]
```

during the testSetup you have to specify an output file by calling the setupReporter function:

`setupReporter('doc/report.md');`

Now you can use the `//@doc` command which writes to the reporting file instead of stdout.

Also a modifier **wrapCode(string what)** is provided which wraps all output in a code block. Here an example:

```
function drawTree() wrapCode("dot") {
  uint numNodes = contract.numNodes();
  //@doc digraph A {
  for(var i=1; i<numNodes; i++) {
    uint parent = contract.getParentForNode(i);
    //@doc node_`uint parent` -> node_`uint i`;
  }
  //@doc }
}
```

Will produce the following code in `doc/report.md`:
```
` ``{dot}
digraph A {
  node_0 -> node_1;
  node_0 -> node_2;
  node_2 -> node_3;
}
` ``
```

with a custom post-processor (like knitr) wrapped code can be further evaluated. In this case to a graphviz image:
![](https://chart.googleapis.com/chart?chl=+digraph+A+%7B%0D%0A++++++node_0+-%3E+node_1%3B%0D%0A++node_0+-%3E+node_2%3B%0D%0A++node_2+-%3E+node_3%3B%0D%0A+%7D%0D%0A++++++++&cht=gv)

