### PR TITLE
enable reporter flag

### DIFF
--- a/cmd/docopt.txt
+++ b/cmd/docopt.txt
@@ -15,3 +15,4 @@ Options:
     -e ENVIRONMENT, --environment ENVIRONMENT [default: evm]
     -c DAPPLERC, --config DAPPLERC
     -s, --subpackages   Include subpackages in output
+    --report            Turn on the reporer


### PR DESCRIPTION
reporter flag was turned off
this enables the reporter in the command line:
`dapple test --report`