### PR TITLE
Fix example test by actually sending the event when a Set is called

### DIFF
--- a/doc/test.md
+++ b/doc/test.md
@@ -15,6 +15,7 @@ contract MyRegistry {
             throw;
         }
         _values[key] = value;
+        Set(key, value);
     }
     function get(bytes32 key) constant returns (bytes32 value) {
         return _values[key];


### PR DESCRIPTION
Making the example event test work by actually producing the event when set function called.