### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/nexusdev/dapple.png?label=ready&title=Ready)](https://waffle.io/nexusdev/dapple)
 ![Dapple](https://ipfs.pics/ipfs/QmdUKEX48hXDgG2Y4XkxKJMV8qojiLYGc2mtEncBcEnSLd)
 
 [![Version](https://img.shields.io/badge/version-0.3.0-8D86C9.svg?style=flat-square)](https://github.com/nexusdev/dapple/releases/tag/0.3.0)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/nexusdev/dapple

This was requested by a real person (user katherineobermeyer) on waffle.io, we're not trying to spam you.