### PR TITLE
JS solc only supports 'sources' opt.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -59,6 +59,10 @@ module.exports = class Builder {
   // implementation if one is not.
   static buildSources (sources, opts) {
     var compiler = solc;
+    var compilerOpts = {
+      sources: sources
+    };
+
     opts = _.assign({
       logger: console,
       errorHandler: function (err) {
@@ -69,15 +73,15 @@ module.exports = class Builder {
     if (NativeCompiler.isAvailable()) {
       opts.logger.info('Using local solc installation...');
       compiler = NativeCompiler;
+      compilerOpts = _.assign({
+        errorHandler: opts.errorHandler,
+        logger: opts.logger
+      }, compilerOpts);
     } else {
       opts.logger.info('No local solc found. Failing over to JS compiler...');
     }
 
-    var solc_out = compiler.compile({
-      sources: sources,
-      errorHandler: opts.errorHandler,
-      logger: opts.logger
-    });
+    var solc_out = compiler.compile(compilerOpts);
 
     if (solc_out.errors) {
       return opts.errorHandler(solc_out.errors);


### PR DESCRIPTION
This fixes the following error when compiling using JS solc.

```
TypeError: Converting circular structure to JSON
```