### PR TITLE
clear defaultAccount on new RPC con, closes #218

### DIFF
--- a/lib/web3Factory.js
+++ b/lib/web3Factory.js
@@ -33,6 +33,7 @@ module.exports = {
     cb = utils.optionalCallback(cb);
 
     var web3 = new Web3(new Web3.providers.HttpProvider(connection_string));
+    web3.eth.defaultAccount = undefined;
     if (typeof opts === 'object' &&
         'web3' in opts &&
         'account' in opts.web3) {


### PR DESCRIPTION
apparently defaultAccount persists over several web3 instances
this closes #218 

```
var Web3 = require('web3');
var web3 = new Web3();
web3.eth.defaultAccount = "0x123";
console.log(web3.eth.defaultAccount);
var _web3 = new Web3();
console.log(_web3.eth.defaultAccount); // should be undefined, but is 0x123
``` 
Also submitting an issue to web3 as this is not the expected behavior.