### PR TITLE
Upgrade ethereumjs-lib to 3.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "deasync": "^0.1.4",
     "dir-compare": "0.0.2",
     "docopt": "^0.6.2",
-    "ethereumjs-lib": "^1.0.1",
+    "ethereumjs-lib": "^3.0.0",
     "ethersim": "git+https://github.com/nexusdev/EtherSim.git#1273c94",
     "file": "^0.2.2",
     "fs-extra": "^0.26.3",


### PR DESCRIPTION
The current dependency on an old version results in a transitive dependency on secp256k1@1.1.4, which is broken on OSX. Newer versions of ethereumjs-lib resolve this issue (there are no newer minor revisions; the issue is only fixed in new major revisions).

Unit tests all still pass after this change.