### PR TITLE
WIP: Multi registries

### DIFF
--- a/cmd/main.js
+++ b/cmd/main.js
@@ -178,6 +178,7 @@ if (cli.install) {
       template: cli['--template'],
       name: workspace.dappfile.name,
       nameFilter: nameFilter,
+      include_tests: cli['--tests'],
       subpackages: cli['--subpackages'] || cli['-s']
     });
 

--- a/lib/dependency.js
+++ b/lib/dependency.js
@@ -219,6 +219,7 @@ module.exports = class Dependency {
       }
     }
 
+    // TODO - iterate through the list
     let address = opts.environment.registries[0];
     let registryClass = Dapphub.getClasses().DappHubSimpleController;
     let dbClass = Dapphub.getClasses().DappHubDB;

--- a/lib/dependency.js
+++ b/lib/dependency.js
@@ -5,7 +5,7 @@ var fs = require('./file.js');
 var path = require('path');
 var req = require('lazreq')({
   constants: './constants.js',
-  dapphub: './dapphub_registry.js',
+  // dapphub: './dapphub_registry.js',
   deasync: 'deasync',
   ipfsAPI: 'ipfs-api',
   os: 'os',
@@ -13,6 +13,7 @@ var req = require('lazreq')({
   Workspace: './workspace.js',
   ipfs: './ipfs.js'
 });
+var Dapphub = require('dapphub');
 var semver = require('semver');
 
 module.exports = class Dependency {
@@ -63,7 +64,7 @@ module.exports = class Dependency {
     return new Dependency(path, version, name);
   }
 
-  install (web3Settings) {
+  install (opts) {
     if (this.getName()) {
       this._throwIfInstalled();
     }
@@ -81,7 +82,7 @@ module.exports = class Dependency {
 
     if (this.getName()) {
       let installedAt = path.join(this.packagesDirectory, this.getName());
-      this.pull(installedAt, web3Settings);
+      this.pull(installedAt, opts);
       this.installedAt = installedAt;
       return true;
     }
@@ -148,10 +149,10 @@ module.exports = class Dependency {
     return this._tmpDir;
   }
 
-  pull (destination, web3Settings) {
+  pull (destination, opts) {
     if (this.hasDappHubPath()) {
       console.log(`installing ${this.name}@${this.version} from dapphub`);
-      this._pullDappHub(web3Settings, destination);
+      this._pullDappHub(opts, destination);
     } else if (this.hasGitPath()) {
       this._pullGit(destination);
     } else if (this.hasIPFSPath()) {
@@ -198,34 +199,41 @@ module.exports = class Dependency {
     }
 
     var fileMap = this.__ipfs.mapAddressToFileSync(rootHash);
+    console.log(Object.keys(fileMap).length);
     this.__ipfs.checkoutFilesSync(target, fileMap);
   }
 
-  _pullDappHub (web3Settings, target) {
-    var web3;
-    if (web3Settings === 'internal') {
+  _pullDappHub (opts, target) {
+    var _web3;
+    if (opts.web3 === 'internal') {
       throw new Error('DappHub registry is not available on internal chains.');
     } else {
       try {
-        web3 = req.Web3Factory.JSONRPC({web3: web3Settings});
+        _web3 = req.Web3Factory.JSONRPC({web3: opts.web3});
       } catch (e) {
         try {
-          web3 = req.Web3Factory.JSONRPC({web3: {host: '104.236.215.91', port: 8545}});
+          _web3 = req.Web3Factory.JSONRPC({web3: {host: '104.236.215.91', port: 8545}});
         } catch (e) {
           throw new Error('Unable to connect to Ethereum client: ' + e);
         }
       }
     }
 
-    let dapphub = new req.dapphub.Class(web3, 'morden');
+    let address = opts.environment.registries[0];
+    let registryClass = Dapphub.getClasses().DappHubSimpleController;
+    let dbClass = Dapphub.getClasses().DappHubDB;
+    let dapphub = _web3.eth.contract(JSON.parse(registryClass.interface)).at(address);
+    let dapphubdbAddress = dapphub._package_db();
+    let dapphubdb = _web3.eth.contract(JSON.parse(dbClass.interface)).at(dapphubdbAddress);
+    // let dapphub = new req.dapphub.Class(_web3, 'morden');
 
     if (this.getVersion() === 'latest') {
       this.path = this.getName();
-      this.version = dapphub.objects.dapphubdb.getLastVersion.call(this.getPath()).join('.');
+      this.version = dapphubdb.getLastVersion.call(this.getPath()).join('.');
     }
 
     // TODO - DEBUG why the fuck this takes so long to call
-    let packageHash = dapphub.objects.dapphubdb.getPackageHash.call(
+    let packageHash = dapphubdb.getPackageHash.call(
         this.getPath(), semver.major(this.getVersion()),
         semver.minor(this.getVersion()), semver.patch(this.getVersion()));
 
@@ -233,7 +241,7 @@ module.exports = class Dependency {
       throw new Error('No IPFS hash found for ' + this.getPath() +
                       '@' + this.getVersion());
     }
-    let packageHeaderHash = web3.toAscii(packageHash);
+    let packageHeaderHash = _web3.toAscii(packageHash);
     console.log(`package id: ${packageHeaderHash}`);
 
     if (!this.__ipfs) {
@@ -245,6 +253,7 @@ module.exports = class Dependency {
     let header = this.__ipfs.catJsonSync(packageHeaderHash);
     // TODO - recursively get the dependencies and install the as well
     this._pullIPFS(header.root, target);
+    console.log('rdy');
   }
 
   _throwIfInstalled () {

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -4,18 +4,19 @@ var _ = require('lodash');
 var Dependency = require('./dependency.js');
 
 module.exports = class Installer {
-  static install (dependencies, logger, web3) {
+  static install (dependencies, logger, web3, environment) {
     if (Array.isArray(dependencies)) {
       dependencies = _.map(dependencies, (d) => [null, d]);
     } else {
       dependencies = _.pairs(dependencies);
     }
     let success = true;
+    let opts = {web3, environment};
     for (let pair of dependencies) {
       try {
         logger.log('Retrieving ' + (pair[0] || pair[1]));
         let dependency = Dependency.fromDependencyString(pair[1], pair[0]);
-        success = dependency.install(web3) && success;
+        success = dependency.install(opts) && success;
         logger.log('Installed ' + dependency.getName() + ' at ' +
                    dependency.installedAt);
       } catch (e) {

--- a/lib/streams/js_postprocess.js
+++ b/lib/streams/js_postprocess.js
@@ -26,6 +26,20 @@ module.exports = function (opts) {
       }));
     }
 
+    if (!opts.include_tests && 'Test' in classes) {
+      var testSignatures = JSON.parse(classes['Test'].interface).map(i => i.name);
+      var testRelated = _.map(classes, (obj, name) => {
+        let sig = JSON.parse(classes[name].interface).map(i => i.name);
+        // console.log(sig);
+        if (_.intersection(sig, testSignatures).length > 100) {
+          return name;
+        }
+        return null;
+      }).filter(n => n !== null).concat(['Reporter', 'Tester', 'Debug']);
+      let goodContracts = _.difference(Object.keys(classes), testRelated);
+      classes = _.pick(classes, goodContracts);
+    }
+
     var headers = Builder.extractClassHeaders(classes);
 
     if (!opts.exportDappleHeaders) {

--- a/lib/streams/publish.js
+++ b/lib/streams/publish.js
@@ -80,7 +80,7 @@ module.exports = function (opts) {
       let major = version[0];
       let minor = version[1];
       let patch = version[2];
-      if(!/^\d+$/.test(major) || !/^\d+$/.test(major) || !/^\d+$/.test(patch)) {
+      if (!/^\d+$/.test(major) || !/^\d+$/.test(major) || !/^\d+$/.test(patch)) {
         throw new Error(`Problem with your semver version in header: "${header.version}" has to match /\\d+\\.\\d+\\.\\d+/ e.g. (1.5.1)`);
       }
 

--- a/lib/streams/publish.js
+++ b/lib/streams/publish.js
@@ -80,6 +80,9 @@ module.exports = function (opts) {
       let major = version[0];
       let minor = version[1];
       let patch = version[2];
+      if(!/^\d+$/.test(major) || !/^\d+$/.test(major) || !/^\d+$/.test(patch)) {
+        throw new Error(`Problem with your semver version in header: "${header.version}" has to match /\\d+\\.\\d+\\.\\d+/ e.g. (1.5.1)`);
+      }
 
       var fromAccount;
       if (typeof opts === 'object' &&
@@ -89,7 +92,6 @@ module.exports = function (opts) {
       } else {
         fromAccount = web3.eth.coinbase || web3.eth.accounts[0];
       }
-      console.log(fromAccount);
 
       // PUBLISH the actual package
       // TODO - test if auth is valid and version is bigger then on the db

--- a/lib/streams/publish.js
+++ b/lib/streams/publish.js
@@ -4,7 +4,8 @@ var through = require('through2');
 var _ = require('lodash');
 var Ipfs = require('../ipfs.js');
 var schemas = require('../schemas.js');
-var Dapphubdb = require('../dapphub_registry.js');
+var Dapphub = require('dapphub');
+// var Dapphubdb = require('../dapphub_registry.js');
 var Web3Factory = require('../web3Factory.js');
 
 var createPackageHeader = function (contracts, rootHash, dappfile, schema) {
@@ -41,7 +42,12 @@ module.exports = function (opts) {
         interface: JSON.parse(obj.interface),
         solidity_interface: obj.solidity_interface
       };
-      var link = ipfs.addJsonSync(Class);
+      try {
+        var link = ipfs.addJsonSync(Class);
+      } catch (e) {
+        console.log(`ERROR: Could not connect to ipfs: is the daemon running on "${opts.ipfs.host}:${opts.ipfs.port}"?`);
+        process.exit();
+      }
       classes[key] = link;
     });
     return classes;
@@ -57,8 +63,18 @@ module.exports = function (opts) {
 
       // Add package to dapphubDb
       var web3 = Web3Factory.JSONRPC(opts);
-      var dapphubdb = new Dapphubdb.Class(web3, 'morden');
-      var dapphub = dapphubdb.objects.dapphubdb;
+
+      let address;
+      if ('registries' in opts.environment && opts.environment.registries.length > 0) {
+        address = opts.environment.registries[0];
+      } else {
+        address = Dapphub.getDappfile().environments.morden.objects.simplecontroller.address;
+      }
+      let registryClass = Dapphub.getClasses().DappHubSimpleController;
+      let dapphub = web3.eth.contract(JSON.parse(registryClass.interface)).at(address);
+
+      // var dapphubdb = new Dapphubdb.Class(web3, 'morden');
+      // var dapphub = dapphubdb.objects.dapphubdb;
 
       var version = header.version.split('.');
       let major = version[0];
@@ -73,6 +89,7 @@ module.exports = function (opts) {
       } else {
         fromAccount = web3.eth.coinbase || web3.eth.accounts[0];
       }
+      console.log(fromAccount);
 
       // PUBLISH the actual package
       // TODO - test if auth is valid and version is bigger then on the db
@@ -81,12 +98,18 @@ module.exports = function (opts) {
         gas: 200000
       }, function (err, res) {
         if (err) throw err;
-        var filter = dapphub.allEvents(function (err, res) {
-          if (err || !res) throw err;
+        if (opts.environment.confirmationBlocks > 0) {
+          var filter = dapphub.allEvents(function (err, res) {
+            if (err || !res) throw err;
+            console.log(`PUBLISH ${header.name}@${major}.${minor}.${patch}: ${headerHash}`);
+            filter.stopWatching();
+            cb();
+          });
+        } else {
+          console.log(res);
           console.log(`PUBLISH ${header.name}@${major}.${minor}.${patch}: ${headerHash}`);
-          filter.stopWatching();
           cb();
-        });
+        }
       });
     } else {
       this.push(file);

--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -92,6 +92,7 @@ module.exports = class Workspace {
         defaults(schemas.dappfile.schema),
         {name: root_dir.split(path.sep).pop()});
     fs.writeYamlSync(dappfilePath, dappfile);
+    fs.mkdirp.sync(path.join(root_dir, '.dapple'));
     var layout = dappfile.layout || {};
     for (let dir in layout) {
       fs.mkdirp.sync(path.join(root_dir, layout[dir]));

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "chai": "^3.4.1",
     "cli-color-tty": "^2.0.0",
-    "dapphub": "0.0.6",
+    "dapphub": "0.0.7",
     "deasync": "^0.1.4",
     "dir-compare": "0.0.2",
     "docopt": "^0.6.2",

--- a/specs/cli.json
+++ b/specs/cli.json
@@ -65,6 +65,10 @@
         {
           "name": "[--no-deploy-data]",
           "summary": "??? TODO"
+        },
+        {
+          "name": "[--tests]",
+          "summary": "include tests into the build"
         }
       ],
       "summary" : "compile and bundle your project",

--- a/specs/dappfile.schema.json
+++ b/specs/dappfile.schema.json
@@ -69,7 +69,7 @@
     },
 
     "environments": {
-      "$ref": "#/definitions/environments"
+      "$ref": "definitions#/definitions/environments"
     }
 
   },
@@ -111,28 +111,6 @@
     "depPath": {
       "type": "string",
       "pattern": ""
-    },
-
-
-    "environments": {
-      "title": "Environments",
-      "description": "Local environments options",
-      "default": {
-        "default": {
-          "ethereum": "internal"
-        },
-        "evm": "default"
-      },
-      "additionalProperties": false,
-      "patternProperties": {
-        "^\\w+$": {
-          "title": "named environment specification",
-          "oneOf": [
-            { "$ref": "definitions#/definitions/environmentRef" },
-            { "$ref": "definitions#/definitions/environmentDescription" }
-          ]
-        }
-      }
     }
   },
 

--- a/specs/dapplerc.schema.json
+++ b/specs/dapplerc.schema.json
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "environments": {
-      "$ref": "dappfile#/definitions/environments"
+      "$ref": "definitions#/definitions/environments"
     }
   },
   "additionalProperties": false,

--- a/specs/definitions.schema.json
+++ b/specs/definitions.schema.json
@@ -104,6 +104,14 @@
           "title": "confirmation blocks",
           "description": "confirmation time after each transaction"
         },
+        "registries": {
+          "title": "regestries",
+          "description": "different regestries sorted by priority",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "ethereum": {
           "oneOf": [
             {
@@ -162,15 +170,27 @@
           }
         }
       }
-
     },
 
-    "environmentSpec": {
-      "oneOf": [
-        { "$ref": "#/definitions/environmentRef" },
-        { "$ref": "#/definitions/environmentDescription" }
-      ],
-      "additionalProperties": false
+    "environments": {
+      "title": "Environments",
+      "description": "Local environments options",
+      "default": {
+        "default": {
+          "ethereum": "internal"
+        },
+        "evm": "default"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\w+$": {
+          "title": "named environment specification",
+          "oneOf": [
+            { "$ref": "definitions#/definitions/environmentRef" },
+            { "$ref": "definitions#/definitions/environmentDescription" }
+          ]
+        }
+      }
     },
 
     "environment": {

--- a/test/workspace_test.js
+++ b/test/workspace_test.js
@@ -16,7 +16,7 @@ describe('class Workspace', function () {
     var dir = fs.tmpdir();
     Workspace.initialize(dir);
     // fs.copySync(dir, testenv.golden.INIT_EMPTY_DIR); //  Create a new golden record
-    var emptyDirs = ['build', 'contracts'];
+    var emptyDirs = ['.dapple', 'build', 'contracts'];
     var ls = fs.readdirSync(dir);
     console.log(_.intersection(ls, emptyDirs), emptyDirs);
     assert.deepEqual(_.intersection(ls, emptyDirs), emptyDirs,
@@ -25,6 +25,7 @@ describe('class Workspace', function () {
     var diff = dircompare.compareSync(dir, testenv.golden.INIT_EMPTY_DIR, {
       excludeFilter: emptyDirs.join(',')
     });
+    console.log(diff);
     assert(diff.same, 'Workspace does not initialize with expected files.');
   });
 

--- a/test/workspace_test.js
+++ b/test/workspace_test.js
@@ -18,6 +18,7 @@ describe('class Workspace', function () {
     // fs.copySync(dir, testenv.golden.INIT_EMPTY_DIR); //  Create a new golden record
     var emptyDirs = ['build', 'contracts'];
     var ls = fs.readdirSync(dir);
+    console.log(_.intersection(ls, emptyDirs), emptyDirs);
     assert.deepEqual(_.intersection(ls, emptyDirs), emptyDirs,
       'Workspace does not initialize with expected empty directories.');
 


### PR DESCRIPTION
Allows the use of multiple and arbitrary registries:

Set up in your dapplerc/ dappfile of an environment:
```
environments:
  morden:
    registries:
      - 0xbb6f9db5f87fd48df747ba8cda538d442633c24f
```

Newest dapple comes from npm instead of build in code.

default registry provided on morden under `0xbb6f9db5f87fd48df747ba8cda538d442633c24f`

name registries are restricted by authority, `beta/` prefixed names are free to use for anybody.

dapple install <path> [<version>] searches for the specified package beginning with the highest priority registry to the lowest, if a match is found it is installed

dapple publish pushes always to the top registry

TODO: 
[ ] install -- iterate through the list
[x] test dapple fresh install
[ ] Write doc/ tutorial/ blogpost how to set up an own registry and use it with dapple

