### PR TITLE
Fix linker collision resolution

### DIFF
--- a/lib/linker.js
+++ b/lib/linker.js
@@ -165,13 +165,16 @@ class Linker {
 
     linked[CONTRACTMAP_KEY] = {};
 
-    for (let sourcePair of _.pairs(dependencyMap)) {
+    var sourcePairs = _.sortBy(_.pairs(dependencyMap),
+                               (pair) => depths[pair[0]]);
+
+    for (let sourcePair of sourcePairs) {
       let path = sourcePair[0];
       if (path === SOURCEMAP_KEY) continue;
 
       let dependencies = sourcePair[1];
       let contractHashes = {};
-      let source = sources[path];
+      let source = path in linked ? linked[path] : sources[path];
       let match;
 
       while ((match = contractDecRegex.exec(source)) !== null) {
@@ -182,10 +185,10 @@ class Linker {
         linked[CONTRACTMAP_KEY][contractHash] = contractName;
 
         // Populate our output mapping.
-        if (!(contractName in contractDepths) ||
-            contractDepths[contractName] > depths[path]) {
-          contractDepths[contractName] = depths[path];
-          contractLocations[contractName] = [path].concat(
+        if (!(contractName in shallowestContracts) ||
+            contractDepths[contractHash] > depths[path]) {
+          contractDepths[contractHash] = depths[path];
+          contractLocations[contractHash] = [path].concat(
             dependencies);
           shallowestContracts[contractName] = contractHash;
         }
@@ -217,7 +220,7 @@ class Linker {
       let contract = pair[0];
       let contractHash = pair[1];
 
-      for (let path of contractLocations[contract]) {
+      for (let path of contractLocations[contractHash]) {
         linked[path] = linked[path].replace(
           new RegExp(contractHash, 'g'), contract);
       }

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -114,11 +114,11 @@ class Linker {
     return depths;
   }
 
-  static dependencyMap (sources) {
+  static importerMap (sources) {
     // Build up a mapping from imported files to the files importing them.
     // We'll use this to update references to contracts as we hash their
     // names.
-    var dependencyMap = {};
+    var importerMap = {};
     var importRegex = /(^\s*import\s*['|""])([^'|"]+)/gm;
 
     for (let sourcePair of _.pairs(sources)) {
@@ -128,23 +128,36 @@ class Linker {
 
       while ((match = importRegex.exec(source)) !== null) {
         let imported = match[2];
-        if (!(imported in dependencyMap)) {
-          dependencyMap[imported] = [];
+        if (!(imported in importerMap)) {
+          importerMap[imported] = [];
         }
-        dependencyMap[imported].push(p);
+        importerMap[imported].push(p);
       }
 
-      if (!(p in dependencyMap)) {
-        dependencyMap[p] = [];
+      if (!(p in importerMap)) {
+        importerMap[p] = [];
       }
     }
-    return dependencyMap;
+    return importerMap;
+  }
+
+  static dependentsList (root, importers, dependents) {
+    if (typeof dependents === 'undefined') {
+      dependents = [];
+    }
+
+    for (let dependent of importers[root]) {
+      if (dependents.indexOf(dependent) > -1) continue;
+      dependents.push(dependent);
+      dependents = this.dependentsList(dependent, importers, dependents);
+    }
+    return dependents;
   }
 
   static linkContracts (sources) {
     var linked = _.cloneDeep(sources);
     var depths = this.contractDepths(linked);
-    var dependencyMap = this.dependencyMap(linked);
+    var importerMap = this.importerMap(linked);
 
     // Now we've got our dependency graph. Let's do one more iteration
     // through the source files and replace contract names with hashes.
@@ -160,23 +173,23 @@ class Linker {
     // returning. This is how we resolve naming collisions. Anything
     // occluded by a naming collision will retain its hashed name.
     let contractDepths = {};
-    let contractLocations = [];
+    let contractLocations = {};
     let shallowestContracts = {};
 
     linked[CONTRACTMAP_KEY] = {};
 
-    var sourcePairs = _.sortBy(_.pairs(dependencyMap),
+    var sourcePairs = _.sortBy(_.pairs(importerMap),
                                (pair) => depths[pair[0]]);
 
     for (let sourcePair of sourcePairs) {
       let path = sourcePair[0];
       if (path === SOURCEMAP_KEY) continue;
 
-      let dependencies = sourcePair[1];
       let contractHashes = {};
       let source = path in linked ? linked[path] : sources[path];
-      let match;
+      let dependents = this.dependentsList(path, importerMap);
 
+      let match;
       while ((match = contractDecRegex.exec(source)) !== null) {
         let contractName = match[2];
         let contractHash = this.uniquifyContractName(
@@ -188,8 +201,7 @@ class Linker {
         if (!(contractName in shallowestContracts) ||
             contractDepths[contractHash] > depths[path]) {
           contractDepths[contractHash] = depths[path];
-          contractLocations[contractHash] = [path].concat(
-            dependencies);
+          contractLocations[contractHash] = [path].concat(dependents);
           shallowestContracts[contractName] = contractHash;
         }
       }
@@ -206,11 +218,12 @@ class Linker {
               return ws1 + contractHashes[name] + ws2;
             });
         }
+
         return source;
       };
 
-      for (let dependency of dependencies) {
-        linked[dependency] = replaceContractNames(linked[dependency]);
+      for (let dependent of dependents) {
+        linked[dependent] = replaceContractNames(linked[dependent]);
       }
       linked[path] = replaceContractNames(source);
     }

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -199,9 +199,9 @@ class Linker {
 
         // Populate our output mapping.
         if (!(contractName in shallowestContracts) ||
-            contractDepths[contractHash] > depths[path]) {
-          contractDepths[contractHash] = depths[path];
-          contractLocations[contractHash] = [path].concat(dependents);
+            contractDepths[contractName] > depths[path]) {
+          contractDepths[contractName] = depths[path];
+          contractLocations[contractName] = [path].concat(dependents);
           shallowestContracts[contractName] = contractHash;
         }
       }
@@ -233,7 +233,7 @@ class Linker {
       let contract = pair[0];
       let contractHash = pair[1];
 
-      for (let path of contractLocations[contractHash]) {
+      for (let path of contractLocations[contract]) {
         linked[path] = linked[path].replace(
           new RegExp(contractHash, 'g'), contract);
       }

--- a/test/_fixtures/linker_test_package/dapple_packages/pkg/src/sol/contract.sol
+++ b/test/_fixtures/linker_test_package/dapple_packages/pkg/src/sol/contract.sol
@@ -1,2 +1,2 @@
 // Intentionally conflicts with the root package's source code.
-contract DapplePkgContract {}
+contract PkgContract {}

--- a/test/_fixtures/linker_test_package/dapple_packages/pkg/src/sol/dapple_contract.sol
+++ b/test/_fixtures/linker_test_package/dapple_packages/pkg/src/sol/dapple_contract.sol
@@ -1,0 +1,3 @@
+import 'contract.sol';
+
+contract DapplePkgContract is PkgContract {}

--- a/test/_fixtures/linker_test_package/src.linked/sol/dapple_contract.sol
+++ b/test/_fixtures/linker_test_package/src.linked/sol/dapple_contract.sol
@@ -1,0 +1,3 @@
+import '<%= contract_hash %>';
+
+contract DapplePkgContract is <%= pkg_contract_hash %> {}

--- a/test/_fixtures/linker_test_package/src.linked/sol/linker_example.sol
+++ b/test/_fixtures/linker_test_package/src.linked/sol/linker_example.sol
@@ -1,5 +1,6 @@
 // The linker should link this to the copy of contract.sol in dapple_packages.
 import '<%= contract_hash %>';
+import '<%= dapple_contract_hash %>';
 
 // The linker should link this to the local copy of contract.sol.
 import '<%= local_contract_hash %>';

--- a/test/_fixtures/linker_test_package/src/sol/linker_example.sol
+++ b/test/_fixtures/linker_test_package/src/sol/linker_example.sol
@@ -1,5 +1,6 @@
 // The linker should link this to the copy of contract.sol in dapple_packages.
 import 'pkg/contract.sol';
+import 'pkg/dapple_contract.sol';
 
 // The linker should link this to the local copy of contract.sol.
 import './pkg/contract.sol';

--- a/test/linker_test.js
+++ b/test/linker_test.js
@@ -90,11 +90,11 @@ describe('Linker', function () {
   it('only puts valid contract names in the contract map', function () {
     var map = Linker.link(workspace, sources)[Linker.CONTRACTMAP_KEY];
     var contractNames = _.values(JSON.parse(map)).sort();
-    assert.deepEqual(contractNames, [
+    assert.deepEqual([
       'DappleLogger', 'DapplePkgContract', 'Debug', 'LinkerExample',
-      'ParenExample', 'PkgContract', 'PkgContract_Test',
+      'ParenExample', 'PkgContract', 'PkgContract', 'PkgContract_Test',
       'Reporter', 'Test', 'Tester'
-    ]);
+    ], contractNames);
   });
 
   it('replaces contract names with hashes', function () {
@@ -117,23 +117,38 @@ describe('Linker', function () {
       constants.PACKAGES_DIRECTORY + '/pkg/src/sol/contract.sol');
     var local_contract_hash = getHashpath(
       'linker_test_package/src/sol/pkg/contract.sol');
+    var dapple_contract_hash = getHashpath(
+      constants.PACKAGES_DIRECTORY + '/pkg/src/sol/dapple_contract.sol');
 
-    var template = _.template(fs.readFileSync(path.join(
+    var local_pkg_contract_hash = Linker.uniquifyContractName(
+      local_contract_hash, 'PkgContract'
+    );
+    var exampleTemplate = _.template(fs.readFileSync(path.join(
       workspace.getPackageRoot(), 'src.linked',
       'sol', 'linker_example.sol'), {encoding: 'utf8'}));
-
-    var expectedOutput = template({
+    var exampleOutput = exampleTemplate({
       contract_hash: contract_hash,
       local_contract_hash: local_contract_hash,
-      pkg_contract_hash: Linker.uniquifyContractName(
-        local_contract_hash, 'PkgContract'
-      ),
+      dapple_contract_hash: dapple_contract_hash,
+      pkg_contract_hash: local_pkg_contract_hash,
       dapple_pkg_contract_hash: Linker.uniquifyContractName(
-        contract_hash, 'DapplePkgContract'
+        dapple_contract_hash, 'DapplePkgContract'
       )
     });
 
+    var pkg_contract_hash = Linker.uniquifyContractName(
+      contract_hash, 'PkgContract'
+    );
+    var dappleContractTemplate = _.template(fs.readFileSync(path.join(
+      workspace.getPackageRoot(), 'src.linked',
+      'sol', 'dapple_contract.sol'), {encoding: 'utf8'}));
+    var dappleContractOutput = dappleContractTemplate({
+      contract_hash: contract_hash,
+      pkg_contract_hash: pkg_contract_hash
+    });
+
     var example_hash = getHashpath('/linker_example.sol');
-    assert.equal(linkedSources[example_hash], expectedOutput);
+    assert.equal(linkedSources[example_hash], exampleOutput);
+    assert.equal(linkedSources[dapple_contract_hash], dappleContractOutput);
   });
 });

--- a/test/linker_test.js
+++ b/test/linker_test.js
@@ -151,4 +151,28 @@ describe('Linker', function () {
     assert.equal(linkedSources[example_hash], exampleOutput);
     assert.equal(linkedSources[dapple_contract_hash], dappleContractOutput);
   });
+
+  it('produces accurate import maps', function () {
+    var sources = {
+      'a.sol': 'import "b.sol"',
+      'b.sol': 'import "c.sol"',
+      'c.sol': ''
+    };
+    var imports = {
+      'a.sol': [],
+      'b.sol': ['a.sol'],
+      'c.sol': ['b.sol']
+    };
+    assert.deepEqual(Linker.importerMap(sources), imports);
+  });
+
+  it('can create lists of dependent files', function () {
+    var imports = {
+      'a.sol': [],
+      'b.sol': ['a.sol'],
+      'c.sol': ['b.sol']
+    };
+    var dependents = ['b.sol', 'a.sol'];
+    assert.deepEqual(Linker.dependentsList('c.sol', imports), dependents);
+  });
 });


### PR DESCRIPTION
I discovered a few problems with the linker and have now fixed them.

First,  contract depth mappings and locations were being keyed by contract name when they should have been keyed by contract location hash. This resulted in the "shallowest contracts" calculation sometimes coming out wrong when there were name collisions.

Second, contract name substitutions bubbled up through the dependency tree were being lost when the bubbling up was done before the dependent source file had been encountered in the `sources` map. Pulling from the `linked` map when available resolved this problem.

Finally, resolving a contract name reference when two source files imported into the same file both define the reference was previously dependent entirely on the order of the source files in the `paths` map (i.e., the first file encountered in the map was the file chosen). I've changed it so that the imported file which is higher in the package hierarchy has precedence. Not sure if this is the ideal solution, but it's at least better-defined now.