### PR TITLE
lib/streams/test.js: convert hex strings to ascii

### DIFF
--- a/constants/debug.sol
+++ b/constants/debug.sol
@@ -1,6 +1,8 @@
 contract Debug {
     event logs(bytes val);
 
+    event log_named_decimal(bytes32 key, uint val, uint decimals);
+
     // Generate log_* and log_named* functions
     /*[[[cog
     import cog

--- a/constants/test.sol
+++ b/constants/test.sol
@@ -43,7 +43,7 @@ contract Test is Debug {
     }
     function assertTrue(bool what) {
         if( !what ) {
-            logs("Expected true but got false");
+            logs("Expected true, got false");
             fail();
         }
     }
@@ -55,7 +55,7 @@ contract Test is Debug {
     }
     function assertFalse(bool what) {
         if( what ) {
-            logs("Expected false but got true");
+            logs("Expected false, got true");
             fail();
         }
     }
@@ -79,8 +79,8 @@ contract Test is Debug {
         }
         if( !ok ) {
             log_bytes32("Error: Wrong `bytes' value");
-            log_named_bytes32("  Actual", "[cannot show `bytes' value]");
             log_named_bytes32("  Expected", "[cannot show `bytes' value]");
+            log_named_bytes32("  Actual", "[cannot show `bytes' value]");
             fail();
         }
     }
@@ -98,8 +98,8 @@ contract Test is Debug {
         }
         if( !ok ) {
             log_bytes32(err);
-            log_named_bytes32("  Actual", "[cannot show `bytes' value]");
             log_named_bytes32("  Expected", "[cannot show `bytes' value]");
+            log_named_bytes32("  Actual", "[cannot show `bytes' value]");
             fail();
         }
     }
@@ -107,8 +107,8 @@ contract Test is Debug {
     function assertEqDecimal(uint a, uint b, uint decimals) {
         if( a != b ) {
             log_bytes32("Error: Wrong fixed-point decimal");
-            log_named_decimal("  Actual", a, decimals);
             log_named_decimal("  Expected", b, decimals);
+            log_named_decimal("  Actual", a, decimals);
             fail();
         }
     }
@@ -126,8 +126,8 @@ contract Test is Debug {
         cog.outl(type + " a, " + type + " b, bytes32 err) {")
         cog.outl("    if( a != b ) {");
         cog.outl("        log_bytes32(err);")
-        cog.outl("        log_named_" + type + "('  Actual', a);")
         cog.outl("        log_named_" + type + "('  Expected', b);")
+        cog.outl("        log_named_" + type + "('  Actual', a);")
         cog.outl("        fail();")
         cog.outl("    }")
         cog.outl("}")
@@ -136,8 +136,8 @@ contract Test is Debug {
         cog.outl(type + " a, " + type + " b) {")
         cog.outl("    if( a != b ) {");
         cog.outl("        log_bytes32(\"Error: Wrong `" + type + "' value\");")
-        cog.outl("        log_named_" + type + "('  Actual', a);")
         cog.outl("        log_named_" + type + "('  Expected', b);")
+        cog.outl("        log_named_" + type + "('  Actual', a);")
         cog.outl("        fail();")
         cog.outl("    }")
         cog.outl("}")
@@ -145,576 +145,576 @@ contract Test is Debug {
     function assertEq(bool a, bool b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bool('  Actual', a);
             log_named_bool('  Expected', b);
+            log_named_bool('  Actual', a);
             fail();
         }
     }
     function assertEq(bool a, bool b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bool' value");
-            log_named_bool('  Actual', a);
             log_named_bool('  Expected', b);
+            log_named_bool('  Actual', a);
             fail();
         }
     }
     function assertEq(uint a, uint b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_uint('  Actual', a);
             log_named_uint('  Expected', b);
+            log_named_uint('  Actual', a);
             fail();
         }
     }
     function assertEq(uint a, uint b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `uint' value");
-            log_named_uint('  Actual', a);
             log_named_uint('  Expected', b);
+            log_named_uint('  Actual', a);
             fail();
         }
     }
     function assertEq(int a, int b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_int('  Actual', a);
             log_named_int('  Expected', b);
+            log_named_int('  Actual', a);
             fail();
         }
     }
     function assertEq(int a, int b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `int' value");
-            log_named_int('  Actual', a);
             log_named_int('  Expected', b);
+            log_named_int('  Actual', a);
             fail();
         }
     }
     function assertEq(address a, address b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_address('  Actual', a);
             log_named_address('  Expected', b);
+            log_named_address('  Actual', a);
             fail();
         }
     }
     function assertEq(address a, address b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `address' value");
-            log_named_address('  Actual', a);
             log_named_address('  Expected', b);
+            log_named_address('  Actual', a);
             fail();
         }
     }
     function assertEq1(bytes1 a, bytes1 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes1('  Actual', a);
             log_named_bytes1('  Expected', b);
+            log_named_bytes1('  Actual', a);
             fail();
         }
     }
     function assertEq1(bytes1 a, bytes1 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes1' value");
-            log_named_bytes1('  Actual', a);
             log_named_bytes1('  Expected', b);
+            log_named_bytes1('  Actual', a);
             fail();
         }
     }
     function assertEq2(bytes2 a, bytes2 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes2('  Actual', a);
             log_named_bytes2('  Expected', b);
+            log_named_bytes2('  Actual', a);
             fail();
         }
     }
     function assertEq2(bytes2 a, bytes2 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes2' value");
-            log_named_bytes2('  Actual', a);
             log_named_bytes2('  Expected', b);
+            log_named_bytes2('  Actual', a);
             fail();
         }
     }
     function assertEq3(bytes3 a, bytes3 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes3('  Actual', a);
             log_named_bytes3('  Expected', b);
+            log_named_bytes3('  Actual', a);
             fail();
         }
     }
     function assertEq3(bytes3 a, bytes3 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes3' value");
-            log_named_bytes3('  Actual', a);
             log_named_bytes3('  Expected', b);
+            log_named_bytes3('  Actual', a);
             fail();
         }
     }
     function assertEq4(bytes4 a, bytes4 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes4('  Actual', a);
             log_named_bytes4('  Expected', b);
+            log_named_bytes4('  Actual', a);
             fail();
         }
     }
     function assertEq4(bytes4 a, bytes4 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes4' value");
-            log_named_bytes4('  Actual', a);
             log_named_bytes4('  Expected', b);
+            log_named_bytes4('  Actual', a);
             fail();
         }
     }
     function assertEq5(bytes5 a, bytes5 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes5('  Actual', a);
             log_named_bytes5('  Expected', b);
+            log_named_bytes5('  Actual', a);
             fail();
         }
     }
     function assertEq5(bytes5 a, bytes5 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes5' value");
-            log_named_bytes5('  Actual', a);
             log_named_bytes5('  Expected', b);
+            log_named_bytes5('  Actual', a);
             fail();
         }
     }
     function assertEq6(bytes6 a, bytes6 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes6('  Actual', a);
             log_named_bytes6('  Expected', b);
+            log_named_bytes6('  Actual', a);
             fail();
         }
     }
     function assertEq6(bytes6 a, bytes6 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes6' value");
-            log_named_bytes6('  Actual', a);
             log_named_bytes6('  Expected', b);
+            log_named_bytes6('  Actual', a);
             fail();
         }
     }
     function assertEq7(bytes7 a, bytes7 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes7('  Actual', a);
             log_named_bytes7('  Expected', b);
+            log_named_bytes7('  Actual', a);
             fail();
         }
     }
     function assertEq7(bytes7 a, bytes7 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes7' value");
-            log_named_bytes7('  Actual', a);
             log_named_bytes7('  Expected', b);
+            log_named_bytes7('  Actual', a);
             fail();
         }
     }
     function assertEq8(bytes8 a, bytes8 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes8('  Actual', a);
             log_named_bytes8('  Expected', b);
+            log_named_bytes8('  Actual', a);
             fail();
         }
     }
     function assertEq8(bytes8 a, bytes8 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes8' value");
-            log_named_bytes8('  Actual', a);
             log_named_bytes8('  Expected', b);
+            log_named_bytes8('  Actual', a);
             fail();
         }
     }
     function assertEq9(bytes9 a, bytes9 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes9('  Actual', a);
             log_named_bytes9('  Expected', b);
+            log_named_bytes9('  Actual', a);
             fail();
         }
     }
     function assertEq9(bytes9 a, bytes9 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes9' value");
-            log_named_bytes9('  Actual', a);
             log_named_bytes9('  Expected', b);
+            log_named_bytes9('  Actual', a);
             fail();
         }
     }
     function assertEq10(bytes10 a, bytes10 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes10('  Actual', a);
             log_named_bytes10('  Expected', b);
+            log_named_bytes10('  Actual', a);
             fail();
         }
     }
     function assertEq10(bytes10 a, bytes10 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes10' value");
-            log_named_bytes10('  Actual', a);
             log_named_bytes10('  Expected', b);
+            log_named_bytes10('  Actual', a);
             fail();
         }
     }
     function assertEq11(bytes11 a, bytes11 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes11('  Actual', a);
             log_named_bytes11('  Expected', b);
+            log_named_bytes11('  Actual', a);
             fail();
         }
     }
     function assertEq11(bytes11 a, bytes11 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes11' value");
-            log_named_bytes11('  Actual', a);
             log_named_bytes11('  Expected', b);
+            log_named_bytes11('  Actual', a);
             fail();
         }
     }
     function assertEq12(bytes12 a, bytes12 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes12('  Actual', a);
             log_named_bytes12('  Expected', b);
+            log_named_bytes12('  Actual', a);
             fail();
         }
     }
     function assertEq12(bytes12 a, bytes12 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes12' value");
-            log_named_bytes12('  Actual', a);
             log_named_bytes12('  Expected', b);
+            log_named_bytes12('  Actual', a);
             fail();
         }
     }
     function assertEq13(bytes13 a, bytes13 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes13('  Actual', a);
             log_named_bytes13('  Expected', b);
+            log_named_bytes13('  Actual', a);
             fail();
         }
     }
     function assertEq13(bytes13 a, bytes13 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes13' value");
-            log_named_bytes13('  Actual', a);
             log_named_bytes13('  Expected', b);
+            log_named_bytes13('  Actual', a);
             fail();
         }
     }
     function assertEq14(bytes14 a, bytes14 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes14('  Actual', a);
             log_named_bytes14('  Expected', b);
+            log_named_bytes14('  Actual', a);
             fail();
         }
     }
     function assertEq14(bytes14 a, bytes14 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes14' value");
-            log_named_bytes14('  Actual', a);
             log_named_bytes14('  Expected', b);
+            log_named_bytes14('  Actual', a);
             fail();
         }
     }
     function assertEq15(bytes15 a, bytes15 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes15('  Actual', a);
             log_named_bytes15('  Expected', b);
+            log_named_bytes15('  Actual', a);
             fail();
         }
     }
     function assertEq15(bytes15 a, bytes15 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes15' value");
-            log_named_bytes15('  Actual', a);
             log_named_bytes15('  Expected', b);
+            log_named_bytes15('  Actual', a);
             fail();
         }
     }
     function assertEq16(bytes16 a, bytes16 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes16('  Actual', a);
             log_named_bytes16('  Expected', b);
+            log_named_bytes16('  Actual', a);
             fail();
         }
     }
     function assertEq16(bytes16 a, bytes16 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes16' value");
-            log_named_bytes16('  Actual', a);
             log_named_bytes16('  Expected', b);
+            log_named_bytes16('  Actual', a);
             fail();
         }
     }
     function assertEq17(bytes17 a, bytes17 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes17('  Actual', a);
             log_named_bytes17('  Expected', b);
+            log_named_bytes17('  Actual', a);
             fail();
         }
     }
     function assertEq17(bytes17 a, bytes17 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes17' value");
-            log_named_bytes17('  Actual', a);
             log_named_bytes17('  Expected', b);
+            log_named_bytes17('  Actual', a);
             fail();
         }
     }
     function assertEq18(bytes18 a, bytes18 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes18('  Actual', a);
             log_named_bytes18('  Expected', b);
+            log_named_bytes18('  Actual', a);
             fail();
         }
     }
     function assertEq18(bytes18 a, bytes18 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes18' value");
-            log_named_bytes18('  Actual', a);
             log_named_bytes18('  Expected', b);
+            log_named_bytes18('  Actual', a);
             fail();
         }
     }
     function assertEq19(bytes19 a, bytes19 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes19('  Actual', a);
             log_named_bytes19('  Expected', b);
+            log_named_bytes19('  Actual', a);
             fail();
         }
     }
     function assertEq19(bytes19 a, bytes19 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes19' value");
-            log_named_bytes19('  Actual', a);
             log_named_bytes19('  Expected', b);
+            log_named_bytes19('  Actual', a);
             fail();
         }
     }
     function assertEq20(bytes20 a, bytes20 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes20('  Actual', a);
             log_named_bytes20('  Expected', b);
+            log_named_bytes20('  Actual', a);
             fail();
         }
     }
     function assertEq20(bytes20 a, bytes20 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes20' value");
-            log_named_bytes20('  Actual', a);
             log_named_bytes20('  Expected', b);
+            log_named_bytes20('  Actual', a);
             fail();
         }
     }
     function assertEq21(bytes21 a, bytes21 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes21('  Actual', a);
             log_named_bytes21('  Expected', b);
+            log_named_bytes21('  Actual', a);
             fail();
         }
     }
     function assertEq21(bytes21 a, bytes21 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes21' value");
-            log_named_bytes21('  Actual', a);
             log_named_bytes21('  Expected', b);
+            log_named_bytes21('  Actual', a);
             fail();
         }
     }
     function assertEq22(bytes22 a, bytes22 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes22('  Actual', a);
             log_named_bytes22('  Expected', b);
+            log_named_bytes22('  Actual', a);
             fail();
         }
     }
     function assertEq22(bytes22 a, bytes22 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes22' value");
-            log_named_bytes22('  Actual', a);
             log_named_bytes22('  Expected', b);
+            log_named_bytes22('  Actual', a);
             fail();
         }
     }
     function assertEq23(bytes23 a, bytes23 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes23('  Actual', a);
             log_named_bytes23('  Expected', b);
+            log_named_bytes23('  Actual', a);
             fail();
         }
     }
     function assertEq23(bytes23 a, bytes23 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes23' value");
-            log_named_bytes23('  Actual', a);
             log_named_bytes23('  Expected', b);
+            log_named_bytes23('  Actual', a);
             fail();
         }
     }
     function assertEq24(bytes24 a, bytes24 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes24('  Actual', a);
             log_named_bytes24('  Expected', b);
+            log_named_bytes24('  Actual', a);
             fail();
         }
     }
     function assertEq24(bytes24 a, bytes24 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes24' value");
-            log_named_bytes24('  Actual', a);
             log_named_bytes24('  Expected', b);
+            log_named_bytes24('  Actual', a);
             fail();
         }
     }
     function assertEq25(bytes25 a, bytes25 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes25('  Actual', a);
             log_named_bytes25('  Expected', b);
+            log_named_bytes25('  Actual', a);
             fail();
         }
     }
     function assertEq25(bytes25 a, bytes25 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes25' value");
-            log_named_bytes25('  Actual', a);
             log_named_bytes25('  Expected', b);
+            log_named_bytes25('  Actual', a);
             fail();
         }
     }
     function assertEq26(bytes26 a, bytes26 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes26('  Actual', a);
             log_named_bytes26('  Expected', b);
+            log_named_bytes26('  Actual', a);
             fail();
         }
     }
     function assertEq26(bytes26 a, bytes26 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes26' value");
-            log_named_bytes26('  Actual', a);
             log_named_bytes26('  Expected', b);
+            log_named_bytes26('  Actual', a);
             fail();
         }
     }
     function assertEq27(bytes27 a, bytes27 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes27('  Actual', a);
             log_named_bytes27('  Expected', b);
+            log_named_bytes27('  Actual', a);
             fail();
         }
     }
     function assertEq27(bytes27 a, bytes27 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes27' value");
-            log_named_bytes27('  Actual', a);
             log_named_bytes27('  Expected', b);
+            log_named_bytes27('  Actual', a);
             fail();
         }
     }
     function assertEq28(bytes28 a, bytes28 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes28('  Actual', a);
             log_named_bytes28('  Expected', b);
+            log_named_bytes28('  Actual', a);
             fail();
         }
     }
     function assertEq28(bytes28 a, bytes28 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes28' value");
-            log_named_bytes28('  Actual', a);
             log_named_bytes28('  Expected', b);
+            log_named_bytes28('  Actual', a);
             fail();
         }
     }
     function assertEq29(bytes29 a, bytes29 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes29('  Actual', a);
             log_named_bytes29('  Expected', b);
+            log_named_bytes29('  Actual', a);
             fail();
         }
     }
     function assertEq29(bytes29 a, bytes29 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes29' value");
-            log_named_bytes29('  Actual', a);
             log_named_bytes29('  Expected', b);
+            log_named_bytes29('  Actual', a);
             fail();
         }
     }
     function assertEq30(bytes30 a, bytes30 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes30('  Actual', a);
             log_named_bytes30('  Expected', b);
+            log_named_bytes30('  Actual', a);
             fail();
         }
     }
     function assertEq30(bytes30 a, bytes30 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes30' value");
-            log_named_bytes30('  Actual', a);
             log_named_bytes30('  Expected', b);
+            log_named_bytes30('  Actual', a);
             fail();
         }
     }
     function assertEq31(bytes31 a, bytes31 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes31('  Actual', a);
             log_named_bytes31('  Expected', b);
+            log_named_bytes31('  Actual', a);
             fail();
         }
     }
     function assertEq31(bytes31 a, bytes31 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes31' value");
-            log_named_bytes31('  Actual', a);
             log_named_bytes31('  Expected', b);
+            log_named_bytes31('  Actual', a);
             fail();
         }
     }
     function assertEq32(bytes32 a, bytes32 b, bytes32 err) {
         if( a != b ) {
             log_bytes32(err);
-            log_named_bytes32('  Actual', a);
             log_named_bytes32('  Expected', b);
+            log_named_bytes32('  Actual', a);
             fail();
         }
     }
     function assertEq32(bytes32 a, bytes32 b) {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes32' value");
-            log_named_bytes32('  Actual', a);
             log_named_bytes32('  Expected', b);
+            log_named_bytes32('  Actual', a);
             fail();
         }
     }

--- a/constants/test.sol
+++ b/constants/test.sol
@@ -104,6 +104,15 @@ contract Test is Debug {
         }
     }
 
+    function assertEqDecimal(uint a, uint b, uint decimals) {
+        if( a != b ) {
+            log_bytes32("Error: Wrong fixed-point decimal");
+            log_named_decimal("  Actual", a, decimals);
+            log_named_decimal("  Expected", b, decimals);
+            fail();
+        }
+    }
+
     /*[[[cog
     import cog
     types = ['bool', 'uint', 'int', 'address']

--- a/constants/test.sol
+++ b/constants/test.sol
@@ -43,26 +43,24 @@ contract Test is Debug {
     }
     function assertTrue(bool what) {
         if( !what ) {
-            logs("assertTrue was false");
+            logs("Expected true but got false");
             fail();
         }
     }
     function assertTrue(bool what, bytes32 error) {
         if( !what ) {
-            logs("assertTrue was false");
             log_bytes32(error);
             fail();
         }
     }
     function assertFalse(bool what) {
         if( what ) {
-            logs("assertFalse was true");
+            logs("Expected false but got true");
             fail();
         }
     }
     function assertFalse(bool what, bytes32 error) {
         if( what ) {
-            logs("assertFalse was true");
             log_bytes32(error);
             fail();
         }
@@ -80,7 +78,9 @@ contract Test is Debug {
             ok = false;
         }
         if( !ok ) {
-            log_bytes32("failed assertEq(bytes)");
+            log_bytes32("Error: Wrong `bytes' value");
+            log_named_bytes32("  Actual", "[cannot show `bytes' value]");
+            log_named_bytes32("  Expected", "[cannot show `bytes' value]");
             fail();
         }
     }
@@ -97,8 +97,9 @@ contract Test is Debug {
             ok = false;
         }
         if( !ok ) {
-            log_bytes32("failed assertEq(bytes)");
             log_bytes32(err);
+            log_named_bytes32("  Actual", "[cannot show `bytes' value]");
+            log_named_bytes32("  Expected", "[cannot show `bytes' value]");
             fail();
         }
     }
@@ -115,10 +116,9 @@ contract Test is Debug {
         cog.out("function " + fname + "(")
         cog.outl(type + " a, " + type + " b, bytes32 err) {")
         cog.outl("    if( a != b ) {");
-        cog.outl("        log_bytes32('Not equal!');")
         cog.outl("        log_bytes32(err);")
-        cog.outl("        log_named_" + type + "('A', a);")
-        cog.outl("        log_named_" + type + "('B', b);")
+        cog.outl("        log_named_" + type + "('  Actual', a);")
+        cog.outl("        log_named_" + type + "('  Expected', b);")
         cog.outl("        fail();")
         cog.outl("    }")
         cog.outl("}")
@@ -126,623 +126,586 @@ contract Test is Debug {
         cog.out("function " + fname + "(")
         cog.outl(type + " a, " + type + " b) {")
         cog.outl("    if( a != b ) {");
-        cog.outl("        log_bytes32('Not equal!');")
-        cog.outl("        log_named_" + type + "('A', a);")
-        cog.outl("        log_named_" + type + "('B', b);")
+        cog.outl("        log_bytes32(\"Error: Wrong `" + type + "' value\");")
+        cog.outl("        log_named_" + type + "('  Actual', a);")
+        cog.outl("        log_named_" + type + "('  Expected', b);")
         cog.outl("        fail();")
         cog.outl("    }")
         cog.outl("}")
     ]]]*/
-
     function assertEq(bool a, bool b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bool('A', a);
-            log_named_bool('B', b);
+            log_named_bool('  Actual', a);
+            log_named_bool('  Expected', b);
             fail();
         }
     }
     function assertEq(bool a, bool b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bool('A', a);
-            log_named_bool('B', b);
+            log_bytes32("Error: Wrong `bool' value");
+            log_named_bool('  Actual', a);
+            log_named_bool('  Expected', b);
             fail();
         }
     }
     function assertEq(uint a, uint b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_uint('A', a);
-            log_named_uint('B', b);
+            log_named_uint('  Actual', a);
+            log_named_uint('  Expected', b);
             fail();
         }
     }
     function assertEq(uint a, uint b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_uint('A', a);
-            log_named_uint('B', b);
+            log_bytes32("Error: Wrong `uint' value");
+            log_named_uint('  Actual', a);
+            log_named_uint('  Expected', b);
             fail();
         }
     }
     function assertEq(int a, int b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_int('A', a);
-            log_named_int('B', b);
+            log_named_int('  Actual', a);
+            log_named_int('  Expected', b);
             fail();
         }
     }
     function assertEq(int a, int b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_int('A', a);
-            log_named_int('B', b);
+            log_bytes32("Error: Wrong `int' value");
+            log_named_int('  Actual', a);
+            log_named_int('  Expected', b);
             fail();
         }
     }
     function assertEq(address a, address b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_address('A', a);
-            log_named_address('B', b);
+            log_named_address('  Actual', a);
+            log_named_address('  Expected', b);
             fail();
         }
     }
     function assertEq(address a, address b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_address('A', a);
-            log_named_address('B', b);
+            log_bytes32("Error: Wrong `address' value");
+            log_named_address('  Actual', a);
+            log_named_address('  Expected', b);
             fail();
         }
     }
     function assertEq1(bytes1 a, bytes1 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes1('A', a);
-            log_named_bytes1('B', b);
+            log_named_bytes1('  Actual', a);
+            log_named_bytes1('  Expected', b);
             fail();
         }
     }
     function assertEq1(bytes1 a, bytes1 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes1('A', a);
-            log_named_bytes1('B', b);
+            log_bytes32("Error: Wrong `bytes1' value");
+            log_named_bytes1('  Actual', a);
+            log_named_bytes1('  Expected', b);
             fail();
         }
     }
     function assertEq2(bytes2 a, bytes2 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes2('A', a);
-            log_named_bytes2('B', b);
+            log_named_bytes2('  Actual', a);
+            log_named_bytes2('  Expected', b);
             fail();
         }
     }
     function assertEq2(bytes2 a, bytes2 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes2('A', a);
-            log_named_bytes2('B', b);
+            log_bytes32("Error: Wrong `bytes2' value");
+            log_named_bytes2('  Actual', a);
+            log_named_bytes2('  Expected', b);
             fail();
         }
     }
     function assertEq3(bytes3 a, bytes3 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes3('A', a);
-            log_named_bytes3('B', b);
+            log_named_bytes3('  Actual', a);
+            log_named_bytes3('  Expected', b);
             fail();
         }
     }
     function assertEq3(bytes3 a, bytes3 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes3('A', a);
-            log_named_bytes3('B', b);
+            log_bytes32("Error: Wrong `bytes3' value");
+            log_named_bytes3('  Actual', a);
+            log_named_bytes3('  Expected', b);
             fail();
         }
     }
     function assertEq4(bytes4 a, bytes4 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes4('A', a);
-            log_named_bytes4('B', b);
+            log_named_bytes4('  Actual', a);
+            log_named_bytes4('  Expected', b);
             fail();
         }
     }
     function assertEq4(bytes4 a, bytes4 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes4('A', a);
-            log_named_bytes4('B', b);
+            log_bytes32("Error: Wrong `bytes4' value");
+            log_named_bytes4('  Actual', a);
+            log_named_bytes4('  Expected', b);
             fail();
         }
     }
     function assertEq5(bytes5 a, bytes5 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes5('A', a);
-            log_named_bytes5('B', b);
+            log_named_bytes5('  Actual', a);
+            log_named_bytes5('  Expected', b);
             fail();
         }
     }
     function assertEq5(bytes5 a, bytes5 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes5('A', a);
-            log_named_bytes5('B', b);
+            log_bytes32("Error: Wrong `bytes5' value");
+            log_named_bytes5('  Actual', a);
+            log_named_bytes5('  Expected', b);
             fail();
         }
     }
     function assertEq6(bytes6 a, bytes6 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes6('A', a);
-            log_named_bytes6('B', b);
+            log_named_bytes6('  Actual', a);
+            log_named_bytes6('  Expected', b);
             fail();
         }
     }
     function assertEq6(bytes6 a, bytes6 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes6('A', a);
-            log_named_bytes6('B', b);
+            log_bytes32("Error: Wrong `bytes6' value");
+            log_named_bytes6('  Actual', a);
+            log_named_bytes6('  Expected', b);
             fail();
         }
     }
     function assertEq7(bytes7 a, bytes7 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes7('A', a);
-            log_named_bytes7('B', b);
+            log_named_bytes7('  Actual', a);
+            log_named_bytes7('  Expected', b);
             fail();
         }
     }
     function assertEq7(bytes7 a, bytes7 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes7('A', a);
-            log_named_bytes7('B', b);
+            log_bytes32("Error: Wrong `bytes7' value");
+            log_named_bytes7('  Actual', a);
+            log_named_bytes7('  Expected', b);
             fail();
         }
     }
     function assertEq8(bytes8 a, bytes8 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes8('A', a);
-            log_named_bytes8('B', b);
+            log_named_bytes8('  Actual', a);
+            log_named_bytes8('  Expected', b);
             fail();
         }
     }
     function assertEq8(bytes8 a, bytes8 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes8('A', a);
-            log_named_bytes8('B', b);
+            log_bytes32("Error: Wrong `bytes8' value");
+            log_named_bytes8('  Actual', a);
+            log_named_bytes8('  Expected', b);
             fail();
         }
     }
     function assertEq9(bytes9 a, bytes9 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes9('A', a);
-            log_named_bytes9('B', b);
+            log_named_bytes9('  Actual', a);
+            log_named_bytes9('  Expected', b);
             fail();
         }
     }
     function assertEq9(bytes9 a, bytes9 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes9('A', a);
-            log_named_bytes9('B', b);
+            log_bytes32("Error: Wrong `bytes9' value");
+            log_named_bytes9('  Actual', a);
+            log_named_bytes9('  Expected', b);
             fail();
         }
     }
     function assertEq10(bytes10 a, bytes10 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes10('A', a);
-            log_named_bytes10('B', b);
+            log_named_bytes10('  Actual', a);
+            log_named_bytes10('  Expected', b);
             fail();
         }
     }
     function assertEq10(bytes10 a, bytes10 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes10('A', a);
-            log_named_bytes10('B', b);
+            log_bytes32("Error: Wrong `bytes10' value");
+            log_named_bytes10('  Actual', a);
+            log_named_bytes10('  Expected', b);
             fail();
         }
     }
     function assertEq11(bytes11 a, bytes11 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes11('A', a);
-            log_named_bytes11('B', b);
+            log_named_bytes11('  Actual', a);
+            log_named_bytes11('  Expected', b);
             fail();
         }
     }
     function assertEq11(bytes11 a, bytes11 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes11('A', a);
-            log_named_bytes11('B', b);
+            log_bytes32("Error: Wrong `bytes11' value");
+            log_named_bytes11('  Actual', a);
+            log_named_bytes11('  Expected', b);
             fail();
         }
     }
     function assertEq12(bytes12 a, bytes12 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes12('A', a);
-            log_named_bytes12('B', b);
+            log_named_bytes12('  Actual', a);
+            log_named_bytes12('  Expected', b);
             fail();
         }
     }
     function assertEq12(bytes12 a, bytes12 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes12('A', a);
-            log_named_bytes12('B', b);
+            log_bytes32("Error: Wrong `bytes12' value");
+            log_named_bytes12('  Actual', a);
+            log_named_bytes12('  Expected', b);
             fail();
         }
     }
     function assertEq13(bytes13 a, bytes13 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes13('A', a);
-            log_named_bytes13('B', b);
+            log_named_bytes13('  Actual', a);
+            log_named_bytes13('  Expected', b);
             fail();
         }
     }
     function assertEq13(bytes13 a, bytes13 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes13('A', a);
-            log_named_bytes13('B', b);
+            log_bytes32("Error: Wrong `bytes13' value");
+            log_named_bytes13('  Actual', a);
+            log_named_bytes13('  Expected', b);
             fail();
         }
     }
     function assertEq14(bytes14 a, bytes14 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes14('A', a);
-            log_named_bytes14('B', b);
+            log_named_bytes14('  Actual', a);
+            log_named_bytes14('  Expected', b);
             fail();
         }
     }
     function assertEq14(bytes14 a, bytes14 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes14('A', a);
-            log_named_bytes14('B', b);
+            log_bytes32("Error: Wrong `bytes14' value");
+            log_named_bytes14('  Actual', a);
+            log_named_bytes14('  Expected', b);
             fail();
         }
     }
     function assertEq15(bytes15 a, bytes15 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes15('A', a);
-            log_named_bytes15('B', b);
+            log_named_bytes15('  Actual', a);
+            log_named_bytes15('  Expected', b);
             fail();
         }
     }
     function assertEq15(bytes15 a, bytes15 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes15('A', a);
-            log_named_bytes15('B', b);
+            log_bytes32("Error: Wrong `bytes15' value");
+            log_named_bytes15('  Actual', a);
+            log_named_bytes15('  Expected', b);
             fail();
         }
     }
     function assertEq16(bytes16 a, bytes16 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes16('A', a);
-            log_named_bytes16('B', b);
+            log_named_bytes16('  Actual', a);
+            log_named_bytes16('  Expected', b);
             fail();
         }
     }
     function assertEq16(bytes16 a, bytes16 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes16('A', a);
-            log_named_bytes16('B', b);
+            log_bytes32("Error: Wrong `bytes16' value");
+            log_named_bytes16('  Actual', a);
+            log_named_bytes16('  Expected', b);
             fail();
         }
     }
     function assertEq17(bytes17 a, bytes17 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes17('A', a);
-            log_named_bytes17('B', b);
+            log_named_bytes17('  Actual', a);
+            log_named_bytes17('  Expected', b);
             fail();
         }
     }
     function assertEq17(bytes17 a, bytes17 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes17('A', a);
-            log_named_bytes17('B', b);
+            log_bytes32("Error: Wrong `bytes17' value");
+            log_named_bytes17('  Actual', a);
+            log_named_bytes17('  Expected', b);
             fail();
         }
     }
     function assertEq18(bytes18 a, bytes18 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes18('A', a);
-            log_named_bytes18('B', b);
+            log_named_bytes18('  Actual', a);
+            log_named_bytes18('  Expected', b);
             fail();
         }
     }
     function assertEq18(bytes18 a, bytes18 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes18('A', a);
-            log_named_bytes18('B', b);
+            log_bytes32("Error: Wrong `bytes18' value");
+            log_named_bytes18('  Actual', a);
+            log_named_bytes18('  Expected', b);
             fail();
         }
     }
     function assertEq19(bytes19 a, bytes19 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes19('A', a);
-            log_named_bytes19('B', b);
+            log_named_bytes19('  Actual', a);
+            log_named_bytes19('  Expected', b);
             fail();
         }
     }
     function assertEq19(bytes19 a, bytes19 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes19('A', a);
-            log_named_bytes19('B', b);
+            log_bytes32("Error: Wrong `bytes19' value");
+            log_named_bytes19('  Actual', a);
+            log_named_bytes19('  Expected', b);
             fail();
         }
     }
     function assertEq20(bytes20 a, bytes20 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes20('A', a);
-            log_named_bytes20('B', b);
+            log_named_bytes20('  Actual', a);
+            log_named_bytes20('  Expected', b);
             fail();
         }
     }
     function assertEq20(bytes20 a, bytes20 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes20('A', a);
-            log_named_bytes20('B', b);
+            log_bytes32("Error: Wrong `bytes20' value");
+            log_named_bytes20('  Actual', a);
+            log_named_bytes20('  Expected', b);
             fail();
         }
     }
     function assertEq21(bytes21 a, bytes21 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes21('A', a);
-            log_named_bytes21('B', b);
+            log_named_bytes21('  Actual', a);
+            log_named_bytes21('  Expected', b);
             fail();
         }
     }
     function assertEq21(bytes21 a, bytes21 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes21('A', a);
-            log_named_bytes21('B', b);
+            log_bytes32("Error: Wrong `bytes21' value");
+            log_named_bytes21('  Actual', a);
+            log_named_bytes21('  Expected', b);
             fail();
         }
     }
     function assertEq22(bytes22 a, bytes22 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes22('A', a);
-            log_named_bytes22('B', b);
+            log_named_bytes22('  Actual', a);
+            log_named_bytes22('  Expected', b);
             fail();
         }
     }
     function assertEq22(bytes22 a, bytes22 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes22('A', a);
-            log_named_bytes22('B', b);
+            log_bytes32("Error: Wrong `bytes22' value");
+            log_named_bytes22('  Actual', a);
+            log_named_bytes22('  Expected', b);
             fail();
         }
     }
     function assertEq23(bytes23 a, bytes23 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes23('A', a);
-            log_named_bytes23('B', b);
+            log_named_bytes23('  Actual', a);
+            log_named_bytes23('  Expected', b);
             fail();
         }
     }
     function assertEq23(bytes23 a, bytes23 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes23('A', a);
-            log_named_bytes23('B', b);
+            log_bytes32("Error: Wrong `bytes23' value");
+            log_named_bytes23('  Actual', a);
+            log_named_bytes23('  Expected', b);
             fail();
         }
     }
     function assertEq24(bytes24 a, bytes24 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes24('A', a);
-            log_named_bytes24('B', b);
+            log_named_bytes24('  Actual', a);
+            log_named_bytes24('  Expected', b);
             fail();
         }
     }
     function assertEq24(bytes24 a, bytes24 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes24('A', a);
-            log_named_bytes24('B', b);
+            log_bytes32("Error: Wrong `bytes24' value");
+            log_named_bytes24('  Actual', a);
+            log_named_bytes24('  Expected', b);
             fail();
         }
     }
     function assertEq25(bytes25 a, bytes25 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes25('A', a);
-            log_named_bytes25('B', b);
+            log_named_bytes25('  Actual', a);
+            log_named_bytes25('  Expected', b);
             fail();
         }
     }
     function assertEq25(bytes25 a, bytes25 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes25('A', a);
-            log_named_bytes25('B', b);
+            log_bytes32("Error: Wrong `bytes25' value");
+            log_named_bytes25('  Actual', a);
+            log_named_bytes25('  Expected', b);
             fail();
         }
     }
     function assertEq26(bytes26 a, bytes26 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes26('A', a);
-            log_named_bytes26('B', b);
+            log_named_bytes26('  Actual', a);
+            log_named_bytes26('  Expected', b);
             fail();
         }
     }
     function assertEq26(bytes26 a, bytes26 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes26('A', a);
-            log_named_bytes26('B', b);
+            log_bytes32("Error: Wrong `bytes26' value");
+            log_named_bytes26('  Actual', a);
+            log_named_bytes26('  Expected', b);
             fail();
         }
     }
     function assertEq27(bytes27 a, bytes27 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes27('A', a);
-            log_named_bytes27('B', b);
+            log_named_bytes27('  Actual', a);
+            log_named_bytes27('  Expected', b);
             fail();
         }
     }
     function assertEq27(bytes27 a, bytes27 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes27('A', a);
-            log_named_bytes27('B', b);
+            log_bytes32("Error: Wrong `bytes27' value");
+            log_named_bytes27('  Actual', a);
+            log_named_bytes27('  Expected', b);
             fail();
         }
     }
     function assertEq28(bytes28 a, bytes28 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes28('A', a);
-            log_named_bytes28('B', b);
+            log_named_bytes28('  Actual', a);
+            log_named_bytes28('  Expected', b);
             fail();
         }
     }
     function assertEq28(bytes28 a, bytes28 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes28('A', a);
-            log_named_bytes28('B', b);
+            log_bytes32("Error: Wrong `bytes28' value");
+            log_named_bytes28('  Actual', a);
+            log_named_bytes28('  Expected', b);
             fail();
         }
     }
     function assertEq29(bytes29 a, bytes29 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes29('A', a);
-            log_named_bytes29('B', b);
+            log_named_bytes29('  Actual', a);
+            log_named_bytes29('  Expected', b);
             fail();
         }
     }
     function assertEq29(bytes29 a, bytes29 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes29('A', a);
-            log_named_bytes29('B', b);
+            log_bytes32("Error: Wrong `bytes29' value");
+            log_named_bytes29('  Actual', a);
+            log_named_bytes29('  Expected', b);
             fail();
         }
     }
     function assertEq30(bytes30 a, bytes30 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes30('A', a);
-            log_named_bytes30('B', b);
+            log_named_bytes30('  Actual', a);
+            log_named_bytes30('  Expected', b);
             fail();
         }
     }
     function assertEq30(bytes30 a, bytes30 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes30('A', a);
-            log_named_bytes30('B', b);
+            log_bytes32("Error: Wrong `bytes30' value");
+            log_named_bytes30('  Actual', a);
+            log_named_bytes30('  Expected', b);
             fail();
         }
     }
     function assertEq31(bytes31 a, bytes31 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes31('A', a);
-            log_named_bytes31('B', b);
+            log_named_bytes31('  Actual', a);
+            log_named_bytes31('  Expected', b);
             fail();
         }
     }
     function assertEq31(bytes31 a, bytes31 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes31('A', a);
-            log_named_bytes31('B', b);
+            log_bytes32("Error: Wrong `bytes31' value");
+            log_named_bytes31('  Actual', a);
+            log_named_bytes31('  Expected', b);
             fail();
         }
     }
     function assertEq32(bytes32 a, bytes32 b, bytes32 err) {
         if( a != b ) {
-            log_bytes32('Not equal!');
             log_bytes32(err);
-            log_named_bytes32('A', a);
-            log_named_bytes32('B', b);
+            log_named_bytes32('  Actual', a);
+            log_named_bytes32('  Expected', b);
             fail();
         }
     }
     function assertEq32(bytes32 a, bytes32 b) {
         if( a != b ) {
-            log_bytes32('Not equal!');
-            log_named_bytes32('A', a);
-            log_named_bytes32('B', b);
+            log_bytes32("Error: Wrong `bytes32' value");
+            log_named_bytes32('  Actual', a);
+            log_named_bytes32('  Expected', b);
             fail();
         }
     }

--- a/constants/test.sol
+++ b/constants/test.sol
@@ -99,7 +99,7 @@ contract Test is Debug {
         if( !ok ) {
             log_bytes32(err);
             log_named_bytes32("  Expected", "[cannot show `bytes' value]");
-            log_named_bytes32("  Actual", "[cannot show `bytes' value]");
+            log_named_bytes32("    Actual", "[cannot show `bytes' value]");
             fail();
         }
     }
@@ -108,7 +108,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong fixed-point decimal");
             log_named_decimal("  Expected", b, decimals);
-            log_named_decimal("  Actual", a, decimals);
+            log_named_decimal("    Actual", a, decimals);
             fail();
         }
     }
@@ -127,7 +127,7 @@ contract Test is Debug {
         cog.outl("    if( a != b ) {");
         cog.outl("        log_bytes32(err);")
         cog.outl("        log_named_" + type + "('  Expected', b);")
-        cog.outl("        log_named_" + type + "('  Actual', a);")
+        cog.outl("        log_named_" + type + "('    Actual', a);")
         cog.outl("        fail();")
         cog.outl("    }")
         cog.outl("}")
@@ -137,7 +137,7 @@ contract Test is Debug {
         cog.outl("    if( a != b ) {");
         cog.outl("        log_bytes32(\"Error: Wrong `" + type + "' value\");")
         cog.outl("        log_named_" + type + "('  Expected', b);")
-        cog.outl("        log_named_" + type + "('  Actual', a);")
+        cog.outl("        log_named_" + type + "('    Actual', a);")
         cog.outl("        fail();")
         cog.outl("    }")
         cog.outl("}")
@@ -146,7 +146,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bool('  Expected', b);
-            log_named_bool('  Actual', a);
+            log_named_bool('    Actual', a);
             fail();
         }
     }
@@ -154,7 +154,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bool' value");
             log_named_bool('  Expected', b);
-            log_named_bool('  Actual', a);
+            log_named_bool('    Actual', a);
             fail();
         }
     }
@@ -162,7 +162,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_uint('  Expected', b);
-            log_named_uint('  Actual', a);
+            log_named_uint('    Actual', a);
             fail();
         }
     }
@@ -170,7 +170,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `uint' value");
             log_named_uint('  Expected', b);
-            log_named_uint('  Actual', a);
+            log_named_uint('    Actual', a);
             fail();
         }
     }
@@ -178,7 +178,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_int('  Expected', b);
-            log_named_int('  Actual', a);
+            log_named_int('    Actual', a);
             fail();
         }
     }
@@ -186,7 +186,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `int' value");
             log_named_int('  Expected', b);
-            log_named_int('  Actual', a);
+            log_named_int('    Actual', a);
             fail();
         }
     }
@@ -194,7 +194,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_address('  Expected', b);
-            log_named_address('  Actual', a);
+            log_named_address('    Actual', a);
             fail();
         }
     }
@@ -202,7 +202,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `address' value");
             log_named_address('  Expected', b);
-            log_named_address('  Actual', a);
+            log_named_address('    Actual', a);
             fail();
         }
     }
@@ -210,7 +210,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes1('  Expected', b);
-            log_named_bytes1('  Actual', a);
+            log_named_bytes1('    Actual', a);
             fail();
         }
     }
@@ -218,7 +218,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes1' value");
             log_named_bytes1('  Expected', b);
-            log_named_bytes1('  Actual', a);
+            log_named_bytes1('    Actual', a);
             fail();
         }
     }
@@ -226,7 +226,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes2('  Expected', b);
-            log_named_bytes2('  Actual', a);
+            log_named_bytes2('    Actual', a);
             fail();
         }
     }
@@ -234,7 +234,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes2' value");
             log_named_bytes2('  Expected', b);
-            log_named_bytes2('  Actual', a);
+            log_named_bytes2('    Actual', a);
             fail();
         }
     }
@@ -242,7 +242,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes3('  Expected', b);
-            log_named_bytes3('  Actual', a);
+            log_named_bytes3('    Actual', a);
             fail();
         }
     }
@@ -250,7 +250,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes3' value");
             log_named_bytes3('  Expected', b);
-            log_named_bytes3('  Actual', a);
+            log_named_bytes3('    Actual', a);
             fail();
         }
     }
@@ -258,7 +258,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes4('  Expected', b);
-            log_named_bytes4('  Actual', a);
+            log_named_bytes4('    Actual', a);
             fail();
         }
     }
@@ -266,7 +266,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes4' value");
             log_named_bytes4('  Expected', b);
-            log_named_bytes4('  Actual', a);
+            log_named_bytes4('    Actual', a);
             fail();
         }
     }
@@ -274,7 +274,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes5('  Expected', b);
-            log_named_bytes5('  Actual', a);
+            log_named_bytes5('    Actual', a);
             fail();
         }
     }
@@ -282,7 +282,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes5' value");
             log_named_bytes5('  Expected', b);
-            log_named_bytes5('  Actual', a);
+            log_named_bytes5('    Actual', a);
             fail();
         }
     }
@@ -290,7 +290,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes6('  Expected', b);
-            log_named_bytes6('  Actual', a);
+            log_named_bytes6('    Actual', a);
             fail();
         }
     }
@@ -298,7 +298,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes6' value");
             log_named_bytes6('  Expected', b);
-            log_named_bytes6('  Actual', a);
+            log_named_bytes6('    Actual', a);
             fail();
         }
     }
@@ -306,7 +306,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes7('  Expected', b);
-            log_named_bytes7('  Actual', a);
+            log_named_bytes7('    Actual', a);
             fail();
         }
     }
@@ -314,7 +314,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes7' value");
             log_named_bytes7('  Expected', b);
-            log_named_bytes7('  Actual', a);
+            log_named_bytes7('    Actual', a);
             fail();
         }
     }
@@ -322,7 +322,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes8('  Expected', b);
-            log_named_bytes8('  Actual', a);
+            log_named_bytes8('    Actual', a);
             fail();
         }
     }
@@ -330,7 +330,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes8' value");
             log_named_bytes8('  Expected', b);
-            log_named_bytes8('  Actual', a);
+            log_named_bytes8('    Actual', a);
             fail();
         }
     }
@@ -338,7 +338,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes9('  Expected', b);
-            log_named_bytes9('  Actual', a);
+            log_named_bytes9('    Actual', a);
             fail();
         }
     }
@@ -346,7 +346,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes9' value");
             log_named_bytes9('  Expected', b);
-            log_named_bytes9('  Actual', a);
+            log_named_bytes9('    Actual', a);
             fail();
         }
     }
@@ -354,7 +354,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes10('  Expected', b);
-            log_named_bytes10('  Actual', a);
+            log_named_bytes10('    Actual', a);
             fail();
         }
     }
@@ -362,7 +362,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes10' value");
             log_named_bytes10('  Expected', b);
-            log_named_bytes10('  Actual', a);
+            log_named_bytes10('    Actual', a);
             fail();
         }
     }
@@ -370,7 +370,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes11('  Expected', b);
-            log_named_bytes11('  Actual', a);
+            log_named_bytes11('    Actual', a);
             fail();
         }
     }
@@ -378,7 +378,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes11' value");
             log_named_bytes11('  Expected', b);
-            log_named_bytes11('  Actual', a);
+            log_named_bytes11('    Actual', a);
             fail();
         }
     }
@@ -386,7 +386,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes12('  Expected', b);
-            log_named_bytes12('  Actual', a);
+            log_named_bytes12('    Actual', a);
             fail();
         }
     }
@@ -394,7 +394,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes12' value");
             log_named_bytes12('  Expected', b);
-            log_named_bytes12('  Actual', a);
+            log_named_bytes12('    Actual', a);
             fail();
         }
     }
@@ -402,7 +402,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes13('  Expected', b);
-            log_named_bytes13('  Actual', a);
+            log_named_bytes13('    Actual', a);
             fail();
         }
     }
@@ -410,7 +410,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes13' value");
             log_named_bytes13('  Expected', b);
-            log_named_bytes13('  Actual', a);
+            log_named_bytes13('    Actual', a);
             fail();
         }
     }
@@ -418,7 +418,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes14('  Expected', b);
-            log_named_bytes14('  Actual', a);
+            log_named_bytes14('    Actual', a);
             fail();
         }
     }
@@ -426,7 +426,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes14' value");
             log_named_bytes14('  Expected', b);
-            log_named_bytes14('  Actual', a);
+            log_named_bytes14('    Actual', a);
             fail();
         }
     }
@@ -434,7 +434,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes15('  Expected', b);
-            log_named_bytes15('  Actual', a);
+            log_named_bytes15('    Actual', a);
             fail();
         }
     }
@@ -442,7 +442,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes15' value");
             log_named_bytes15('  Expected', b);
-            log_named_bytes15('  Actual', a);
+            log_named_bytes15('    Actual', a);
             fail();
         }
     }
@@ -450,7 +450,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes16('  Expected', b);
-            log_named_bytes16('  Actual', a);
+            log_named_bytes16('    Actual', a);
             fail();
         }
     }
@@ -458,7 +458,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes16' value");
             log_named_bytes16('  Expected', b);
-            log_named_bytes16('  Actual', a);
+            log_named_bytes16('    Actual', a);
             fail();
         }
     }
@@ -466,7 +466,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes17('  Expected', b);
-            log_named_bytes17('  Actual', a);
+            log_named_bytes17('    Actual', a);
             fail();
         }
     }
@@ -474,7 +474,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes17' value");
             log_named_bytes17('  Expected', b);
-            log_named_bytes17('  Actual', a);
+            log_named_bytes17('    Actual', a);
             fail();
         }
     }
@@ -482,7 +482,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes18('  Expected', b);
-            log_named_bytes18('  Actual', a);
+            log_named_bytes18('    Actual', a);
             fail();
         }
     }
@@ -490,7 +490,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes18' value");
             log_named_bytes18('  Expected', b);
-            log_named_bytes18('  Actual', a);
+            log_named_bytes18('    Actual', a);
             fail();
         }
     }
@@ -498,7 +498,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes19('  Expected', b);
-            log_named_bytes19('  Actual', a);
+            log_named_bytes19('    Actual', a);
             fail();
         }
     }
@@ -506,7 +506,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes19' value");
             log_named_bytes19('  Expected', b);
-            log_named_bytes19('  Actual', a);
+            log_named_bytes19('    Actual', a);
             fail();
         }
     }
@@ -514,7 +514,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes20('  Expected', b);
-            log_named_bytes20('  Actual', a);
+            log_named_bytes20('    Actual', a);
             fail();
         }
     }
@@ -522,7 +522,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes20' value");
             log_named_bytes20('  Expected', b);
-            log_named_bytes20('  Actual', a);
+            log_named_bytes20('    Actual', a);
             fail();
         }
     }
@@ -530,7 +530,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes21('  Expected', b);
-            log_named_bytes21('  Actual', a);
+            log_named_bytes21('    Actual', a);
             fail();
         }
     }
@@ -538,7 +538,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes21' value");
             log_named_bytes21('  Expected', b);
-            log_named_bytes21('  Actual', a);
+            log_named_bytes21('    Actual', a);
             fail();
         }
     }
@@ -546,7 +546,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes22('  Expected', b);
-            log_named_bytes22('  Actual', a);
+            log_named_bytes22('    Actual', a);
             fail();
         }
     }
@@ -554,7 +554,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes22' value");
             log_named_bytes22('  Expected', b);
-            log_named_bytes22('  Actual', a);
+            log_named_bytes22('    Actual', a);
             fail();
         }
     }
@@ -562,7 +562,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes23('  Expected', b);
-            log_named_bytes23('  Actual', a);
+            log_named_bytes23('    Actual', a);
             fail();
         }
     }
@@ -570,7 +570,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes23' value");
             log_named_bytes23('  Expected', b);
-            log_named_bytes23('  Actual', a);
+            log_named_bytes23('    Actual', a);
             fail();
         }
     }
@@ -578,7 +578,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes24('  Expected', b);
-            log_named_bytes24('  Actual', a);
+            log_named_bytes24('    Actual', a);
             fail();
         }
     }
@@ -586,7 +586,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes24' value");
             log_named_bytes24('  Expected', b);
-            log_named_bytes24('  Actual', a);
+            log_named_bytes24('    Actual', a);
             fail();
         }
     }
@@ -594,7 +594,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes25('  Expected', b);
-            log_named_bytes25('  Actual', a);
+            log_named_bytes25('    Actual', a);
             fail();
         }
     }
@@ -602,7 +602,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes25' value");
             log_named_bytes25('  Expected', b);
-            log_named_bytes25('  Actual', a);
+            log_named_bytes25('    Actual', a);
             fail();
         }
     }
@@ -610,7 +610,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes26('  Expected', b);
-            log_named_bytes26('  Actual', a);
+            log_named_bytes26('    Actual', a);
             fail();
         }
     }
@@ -618,7 +618,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes26' value");
             log_named_bytes26('  Expected', b);
-            log_named_bytes26('  Actual', a);
+            log_named_bytes26('    Actual', a);
             fail();
         }
     }
@@ -626,7 +626,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes27('  Expected', b);
-            log_named_bytes27('  Actual', a);
+            log_named_bytes27('    Actual', a);
             fail();
         }
     }
@@ -634,7 +634,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes27' value");
             log_named_bytes27('  Expected', b);
-            log_named_bytes27('  Actual', a);
+            log_named_bytes27('    Actual', a);
             fail();
         }
     }
@@ -642,7 +642,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes28('  Expected', b);
-            log_named_bytes28('  Actual', a);
+            log_named_bytes28('    Actual', a);
             fail();
         }
     }
@@ -650,7 +650,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes28' value");
             log_named_bytes28('  Expected', b);
-            log_named_bytes28('  Actual', a);
+            log_named_bytes28('    Actual', a);
             fail();
         }
     }
@@ -658,7 +658,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes29('  Expected', b);
-            log_named_bytes29('  Actual', a);
+            log_named_bytes29('    Actual', a);
             fail();
         }
     }
@@ -666,7 +666,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes29' value");
             log_named_bytes29('  Expected', b);
-            log_named_bytes29('  Actual', a);
+            log_named_bytes29('    Actual', a);
             fail();
         }
     }
@@ -674,7 +674,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes30('  Expected', b);
-            log_named_bytes30('  Actual', a);
+            log_named_bytes30('    Actual', a);
             fail();
         }
     }
@@ -682,7 +682,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes30' value");
             log_named_bytes30('  Expected', b);
-            log_named_bytes30('  Actual', a);
+            log_named_bytes30('    Actual', a);
             fail();
         }
     }
@@ -690,7 +690,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes31('  Expected', b);
-            log_named_bytes31('  Actual', a);
+            log_named_bytes31('    Actual', a);
             fail();
         }
     }
@@ -698,7 +698,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes31' value");
             log_named_bytes31('  Expected', b);
-            log_named_bytes31('  Actual', a);
+            log_named_bytes31('    Actual', a);
             fail();
         }
     }
@@ -706,7 +706,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32(err);
             log_named_bytes32('  Expected', b);
-            log_named_bytes32('  Actual', a);
+            log_named_bytes32('    Actual', a);
             fail();
         }
     }
@@ -714,7 +714,7 @@ contract Test is Debug {
         if( a != b ) {
             log_bytes32("Error: Wrong `bytes32' value");
             log_named_bytes32('  Expected', b);
-            log_named_bytes32('  Actual', a);
+            log_named_bytes32('    Actual', a);
             fail();
         }
     }

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+var BigNumber = require('bignumber.js');
 var clc = require('cli-color-tty')(true);
 var Contract = require('../contract');
 var deasync = require('deasync');
@@ -57,7 +58,11 @@ function runTests (stream, className, vmTest, logTranslator) {
       } else if (entry.event.indexOf('log_id_') > -1 && LogTranslator.logs[entry.event].type === 'doc') {
         report += LogTranslator.format(entry) + '\n';
       } else if (entry.event.indexOf('_named_') > -1) {
-        output += logPrefix + toAscii(entry.args.key) + ': ' + entry.args.val + '\n';
+        var key = rpad(toAscii(entry.args.key) + ': ', 12);
+        var val = entry.args.decimals
+          ? toDecimal(entry.args.val, entry.args.decimals)
+          : entry.args.val
+        output += logPrefix + key + val + '\n';
       } else if (entry.event.indexOf('log_id_') > -1) {
         output += '  ' + LogTranslator.format(entry) + '\n';
       } else if (entry.event === 'log_bytes32') {
@@ -151,5 +156,19 @@ function toAscii (hex) {
   for (var i = 0; i < hex.length - 1; i += 2) {
     result += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
   }
-  return result;
+  return result.replace(/\0/g, '');
+}
+
+function rpad (string, length) {
+  return string + repeat(' ', Math.max(0, length - string.length))
+}
+
+function repeat (string, n) {
+  return new Array(n + 1).join(string);
+}
+
+function toDecimal (value, decimals) {
+  return new BigNumber(value)
+    .div(new BigNumber(10).pow(decimals))
+    .toFixed(decimals);
 }

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -60,7 +60,7 @@ function runTests (stream, className, vmTest, logTranslator) {
         output += logPrefix + toAscii(entry.args.key) + ': ' + entry.args.val + '\n';
       } else if (entry.event.indexOf('log_id_') > -1) {
         output += '  ' + LogTranslator.format(entry) + '\n';
-      } else if (entry.event == 'log_bytes32') {
+      } else if (entry.event === 'log_bytes32') {
         output += logPrefix + toAscii(entry.args.val) + '\n';
       } else {
         output += logPrefix + entry.event + '\n';

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -57,7 +57,7 @@ function runTests (stream, className, vmTest, logTranslator) {
       } else if (entry.event.indexOf('log_id_') > -1 && LogTranslator.logs[entry.event].type === 'doc') {
         report += LogTranslator.format(entry) + '\n';
       } else if (entry.event.indexOf('_named_') > -1) {
-        output += logPrefix + entry.args.key + ': ' + entry.args.val + '\n';
+        output += logPrefix + toAscii(entry.args.key) + ': ' + entry.args.val + '\n';
       } else if (entry.event.indexOf('log_id_') > -1) {
         output += '  ' + LogTranslator.format(entry) + '\n';
       } else {
@@ -65,7 +65,7 @@ function runTests (stream, className, vmTest, logTranslator) {
 
         for (let arg of _.pairs(entry.args)) {
           output += logPrefix + '  ' +
-            arg[0] + ': ' + arg[1] + '\n';
+            arg[0] + ': ' + toAscii(arg[1]) + '\n';
         }
       }
     }
@@ -142,3 +142,11 @@ module.exports = function (opts) {
     cb();
   });
 };
+
+function toAscii(hex) {
+  hex = hex.replace(/^0x/, "");
+  var result = "";
+  for (var i = 0; i < hex.length - 1; i += 2)
+    result += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
+  return result;
+}

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -61,7 +61,7 @@ function runTests (stream, className, vmTest, logTranslator) {
         var key = toAscii(entry.args.key) + ': ';
         var val = entry.args.decimals
           ? toDecimal(entry.args.val, entry.args.decimals)
-          : entry.args.val
+          : entry.args.val;
         output += logPrefix + key + val + '\n';
       } else if (entry.event.indexOf('log_id_') > -1) {
         output += '  ' + LogTranslator.format(entry) + '\n';
@@ -160,7 +160,7 @@ function toAscii (hex) {
 }
 
 function toDecimal (value, decimals) {
-  return new BigNumber(value)
-    .div(new BigNumber(10).pow(decimals))
-    .toFixed(decimals);
+  return new BigNumber(value).
+    div(new BigNumber(10).pow(decimals)).
+    toFixed(decimals);
 }

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -143,10 +143,11 @@ module.exports = function (opts) {
   });
 };
 
-function toAscii(hex) {
-  hex = hex.replace(/^0x/, "");
-  var result = "";
-  for (var i = 0; i < hex.length - 1; i += 2)
-    result += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
+function toAscii (hex) {
+  hex = hex.replace(/^0x/, '');
+  var result = '';
+  for (var i = 0; i < hex.length - 1; i += 2) {
+    result += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+  }
   return result;
 }

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -58,7 +58,7 @@ function runTests (stream, className, vmTest, logTranslator) {
       } else if (entry.event.indexOf('log_id_') > -1 && LogTranslator.logs[entry.event].type === 'doc') {
         report += LogTranslator.format(entry) + '\n';
       } else if (entry.event.indexOf('_named_') > -1) {
-        var key = rpad(toAscii(entry.args.key) + ': ', 12);
+        var key = toAscii(entry.args.key) + ': ';
         var val = entry.args.decimals
           ? toDecimal(entry.args.val, entry.args.decimals)
           : entry.args.val
@@ -157,14 +157,6 @@ function toAscii (hex) {
     result += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
   }
   return result.replace(/\0/g, '');
-}
-
-function rpad (string, length) {
-  return string + repeat(' ', Math.max(0, length - string.length))
-}
-
-function repeat (string, n) {
-  return new Array(n + 1).join(string);
 }
 
 function toDecimal (value, decimals) {

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -160,7 +160,7 @@ function toAscii (hex) {
 }
 
 function toDecimal (value, decimals) {
-  return new BigNumber(value).
-    div(new BigNumber(10).pow(decimals)).
-    toFixed(decimals);
+  return new BigNumber(value)
+    .div(new BigNumber(10).pow(decimals))
+    .toFixed(decimals);
 }

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -47,7 +47,7 @@ function runTests (stream, className, vmTest, logTranslator) {
     // a discreet logical chunk that belongs in
     // its own function or class somewhere.
     var output = result.title + '\n';
-    var logPrefix = '  LOG:  ';
+    var logPrefix = '  | ';
     var report = '';
     for (let entry of result.logs) {
       if (entry.event === '__startBlockE') {
@@ -60,6 +60,8 @@ function runTests (stream, className, vmTest, logTranslator) {
         output += logPrefix + toAscii(entry.args.key) + ': ' + entry.args.val + '\n';
       } else if (entry.event.indexOf('log_id_') > -1) {
         output += '  ' + LogTranslator.format(entry) + '\n';
+      } else if (entry.event == 'log_bytes32') {
+        output += logPrefix + toAscii(entry.args.val) + '\n';
       } else {
         output += logPrefix + entry.event + '\n';
 

--- a/lib/streams/test.js
+++ b/lib/streams/test.js
@@ -67,7 +67,7 @@ function runTests (stream, className, vmTest, logTranslator) {
 
         for (let arg of _.pairs(entry.args)) {
           output += logPrefix + '  ' +
-            arg[0] + ': ' + toAscii(arg[1]) + '\n';
+            arg[0] + ': ' + arg[1] + '\n';
         }
       }
     }


### PR DESCRIPTION
This change turns the following test output:

```
MakerTest
  test basic locking and freeing
  LOG:  log_bytes32
  LOG:    val: 0x4e6f7420657175616c2100000000000000000000000000000000000000000000
  LOG:  0x4100000000000000000000000000000000000000000000000000000000000000: 100
  LOG:  0x4200000000000000000000000000000000000000000000000000000000000000: 70
  LOG:  log_bytes32
  LOG:    val: 0x4e6f7420657175616c2100000000000000000000000000000000000000000000
  LOG:  0x4100000000000000000000000000000000000000000000000000000000000000: 100
  LOG:  0x4200000000000000000000000000000000000000000000000000000000000000: 80
  Failed!
```

into this:

```
MakerTest
  test basic locking and freeing
  LOG:  log_bytes32
  LOG:    val: Not equal!
  LOG:  A: 100
  LOG:  B: 70
  LOG:  log_bytes32
  LOG:    val: Not equal!
  LOG:  A: 100
  LOG:  B: 80
  Failed!
```

See any problems with this @ryepdx @denis @nikolai?