### PR TITLE
Update version of Node to latest in order to support the ES6 features…

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "write-yaml": "^0.2.2"
   },
   "engines": {
-    "node": ">=5.0.0"
+    "node": ">=6.5.0"
   },
   "devDependencies": {
     "eslint": "^1.10.3",


### PR DESCRIPTION
… we're using.

I tried running `dapple --version` with the copy of Node in the dev Docker image (Node 5.11.1, I think) and got syntax errors from the ES6 code. Upgraded to 6.5 and they went away. Might be possible to require a lower version of Node, of course. What version are you running, @mhhf ?