### PR TITLE
Fix typo hahs -> hash in dapple doctor

### DIFF
--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -45,7 +45,7 @@ const doctorDappleRc = () => {
         ok: isOk(`http://${env.env.ethereum.host}:${env.env.ethereum.port}`)
       }; })
     .map(env => {
-      let stats = `\ngenesis-hahs: ${env.ok.genesis}\nblock-height: ${env.ok.height}\n`;
+      let stats = `\ngenesis-hash: ${env.ok.genesis}\nblock-height: ${env.ok.height}\n`;
       return `Environment ${clc.bold(env.name)}: ${env.ok.ok ? (clc.green('OK!') + stats) : clc.red('no connection on ' + env.uri + '\n')}`;
     })
     .join('\n');


### PR DESCRIPTION
Small typo change.

```bash
testing packages
Analyzing your dapplerc
checking the status of each environment, this might take a while...
Environment morden: OK!
genesis-hahs: 0x.....
block-height: 20000001

[ '', 'ip4', '127.0.0.1', 'tcp', '5001' ]
```

I see that this code is disabled in the  v0.8 branch, so not sure if this is worth merging.

