### PR TITLE
fix solidity 0.3.6 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
   },
   "dependencies": {
     "cli-color-tty": "^2.0.0",
-    "dapple-core": "^0.1.11",
-    "dapple-script": "^0.0.18",
-    "dapple-test": "0.0.7-dev",
+    "dapple-core": "^0.1.12",
+    "dapple-script": "^0.0.19",
+    "dapple-test": "0.0.8-dev",
     "dapple-pkg": "^0.0.6-dev",
     "dapple-nss": "^1.0.0",
     "deasync": "^0.1.7",


### PR DESCRIPTION
Error was because from solidity 0.3.6 upwards, contract's fallback function throws by default, if not implemented but used. with this you have to explicitly implement an empty fallback function in case you want to be able to send funds to a contract.