### PR TITLE
Have constructor accept a string as the environment

### DIFF
--- a/constants/build_templates/js_module.template
+++ b/constants/build_templates/js_module.template
@@ -52,14 +52,14 @@ if (typeof dapple === 'undefined') {
     if (!env) {
       env = <%= env %>;
     }
-    if(!("objects" in env) && typeof env === "object") {
+    if(typeof env === "object" && !("objects" in env)) {
       env = {objects: env};
     }
     while (typeof env !== 'object') {
       if (!(env in environments)) {
         throw new Error('Cannot resolve environment name: ' + env);
       }
-      env = environments[env];
+      env = {objects: environments[env]};
     }
 
     if (typeof _web3 === 'undefined') {


### PR DESCRIPTION
With this change we can send a string as the environment again.

For example, if I instantiate a class as dapple['factory'].class(web3, 'morden') it will look in the "environments" variable for it. If it finds it it'll wrap it around "objects".