### PR TITLE
Update documentation

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -13,31 +13,31 @@ with a couple of other directories:
 $ tree .
 .
 ├── build
-├── contracts
-└── dappfile
+├── Dappfile
+└── src
 
 2 directories, 1 file
 ```
 
 By default, `build/` is where the output of `dapple build` gets put,
-and `contracts/` is where Dapple looks for your contract source files.
-Both of these are configured in your `dappfile` and can be overridden.
+and `src/` is where Dapple looks for your contract source files.
+Both of these are configured in your `Dappfile` and can be overridden.
 
 Now try writing a contract and a test (see [Dapple test harness docs](test.md)):
 
-    $ vim contracts/dapp.sol
-    $ vim contracts/dapp_test.sol
+    $ vim src/dapp.sol
+    $ vim src/dapp_test.sol
     $ dapple test
 
 Finally, try building your project:
 
     $ dapple build
 
-By default, `dapple build` builds the entire `contracts/` tree, and
+By default, `dapple build` builds the entire `src/` tree, and
 emits the following:
 
 * cached build objects
 * `classes.json` — a list of type definitions
 * `js_module.js` — a JavaScript module which wraps `classes.json` and
 adds `Contract` objects instantiated from `web3.js` for each object in
-the `dappfile`
+the `Dappfile`


### PR DESCRIPTION
`Dappfile` name and default contract directory were changed in: https://github.com/nexusdev/dapple/commit/b2381f8d8be264a904e849178769969cd9130d14